### PR TITLE
Replace the dependency on yajl with multi_json

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob("spec/**/*")
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.add_dependency 'yajl-ruby', '>= 1.1.0'
+  s.add_dependency 'multi_json', '~> 1.0.4'
   s.add_dependency 'oauth', '~> 0.4.5'
   s.add_dependency 'addressable', '~> 2.2.6'
   s.add_dependency 'rest-client', '~> 1.6.7'


### PR DESCRIPTION
I went to install this on a windows machine and couldn't because yajl requires 'make' for the native extension. It doesn't look like yajl itself is referenced anywhere so replacing the dependency with multi_json works fine. I've tested this on Windows under JRuby, but it should work fine under MRI as well.
