### PR TITLE
Create and update checklists

### DIFF
--- a/lib/trello/checklist.rb
+++ b/lib/trello/checklist.rb
@@ -14,7 +14,7 @@ module Trello
 
       def create(options)
         new('name'       => options[:name],
-            'idBoard'    => options[:board_id]).save!
+            'idBoard'    => options[:board_id]).save
       end
     end
 
@@ -50,7 +50,7 @@ module Trello
     end
 
     def update!
-      Client.put("/checklists", { :name => name }).json_into(self)
+      Client.put("/checklists/#{id}", { :name => name }).json_into(self)
     end
 
     # Return a list of items on the checklist.

--- a/spec/checklist_spec.rb
+++ b/spec/checklist_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Trello
+  describe Checklist do
+    include Helpers
+
+    before(:each) do
+      Client.stub(:get).with("/checklists/abcdef123456789123456789").
+        and_return JSON.generate(checklists_details.first)
+
+      @checklist = Checklist.find('abcdef123456789123456789')
+    end
+
+    context "creating" do
+      it 'creates a new record and saves it on Trello', :refactor => true do
+        payload = {
+          :name    => 'Test Checklist',
+          :desc    => '',
+        }
+
+        result = JSON.generate(checklists_details.first.merge(payload.merge(:idBoard => boards_details.first['id'])))
+
+        expected_payload = {:name => "Test Checklist", :idBoard => "abcdef123456789123456789"}
+
+        Client.should_receive(:post).with("/checklists", expected_payload).and_return result
+
+        checklist = Checklist.create(checklists_details.first.merge(payload.merge(:board_id => boards_details.first['id'])))
+
+        checklist.class.should be Checklist
+      end
+    end
+
+    context "updating" do
+      it "updating name does a put on the correct resource with the correct value" do
+        expected_new_name = "xxx"
+        expected_resource = "/checklists/#{@checklist.id}"
+        payload = {
+          :name      => expected_new_name
+        }
+
+        result = JSON.generate(checklists_details.first)
+        Client.should_receive(:put).once.with("/checklists/abcdef123456789123456789", payload).and_return result
+        checklist = @checklist.dup
+        checklist.name = expected_new_name
+        checklist.save
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Saving a new checklist and updating an existing one with a new name seemed to be broken. Here's a fix.
