### PR TITLE
Fixed a broken spec on Card

### DIFF
--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -56,7 +56,8 @@ module Trello
           :closed    => false,
           :idList    => "abcdef123456789123456789",
           :idBoard   => "abcdef123456789123456789",
-          :idMembers => ["abcdef123456789123456789"]
+          :idMembers => ["abcdef123456789123456789"],
+          :pos       => 12
         }
 
         Client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,8 @@ module Helpers
       "idList"    => "abcdef123456789123456789",
       "idBoard"   => "abcdef123456789123456789",
       "idMembers" => ["abcdef123456789123456789"],
-      "url"       => "https://trello.com/card/board/specify-the-type-and-scope-of-the-jit-in-a-lightweight-spec/abcdef123456789123456789/abcdef123456789123456789"
+      "url"       => "https://trello.com/card/board/specify-the-type-and-scope-of-the-jit-in-a-lightweight-spec/abcdef123456789123456789/abcdef123456789123456789",
+      "pos"       => 12
     }]
   end
 


### PR DESCRIPTION
The spec was failing because of the incomplete data created by the cards_details helper method, which did not consider the 'pos' card field.
Moreover, in this spec, which tested just the card name update, probably all the other data simply may be ignored, since it's not relevant to the spec itself (IMHO).
