### PR TITLE
Add close methods to lists and cards

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -101,6 +101,20 @@ module Trello
       })
     end
 
+    # Check if the card is not active anymore.
+    def closed?
+      closed
+    end
+
+    def close
+      self.closed = true
+    end
+
+    def close!
+      close
+      save
+    end
+
     # Is the record valid?
     def valid?
       name && list_id
@@ -191,6 +205,5 @@ module Trello
     def request_prefix
       "/cards/#{id}"
     end
-
   end
 end

--- a/lib/trello/list.rb
+++ b/lib/trello/list.rb
@@ -53,6 +53,15 @@ module Trello
       closed
     end
 
+    def close
+      self.closed = true
+    end
+
+    def close!
+      close
+      save
+    end
+
     # Return the board the list is connected to.
     one :board, :using => :board_id
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -252,5 +252,38 @@ module Trello
         @card.errors.should be_empty
       end
     end
+
+    describe "#closed?" do
+      it "returns the closed attribute" do
+        @card.closed?.should_not be_true
+      end
+    end
+
+    describe "#close" do
+      it "updates the close attribute to true" do
+        @card.close
+        @card.closed.should be_true
+      end
+    end
+
+    describe "#close!" do
+      it "updates the close attribute to true and saves the list" do
+        payload = {
+          :name      => @card.name,
+          :desc      => "Awesome things are awesome.",
+          :due       => nil,
+          :closed    => true,
+          :idList    => "abcdef123456789123456789",
+          :idBoard   => "abcdef123456789123456789",
+          :idMembers => ["abcdef123456789123456789"],
+          :pos       => 12
+        }
+
+        Client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)
+
+        @card.close!
+      end
+    end
+
   end
 end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -21,9 +21,8 @@ module Trello
         }
 
         Client.should_receive(:put).once.with("/lists/abcdef123456789123456789", payload)
-        list = @list.dup
-        list.name = expected_new_name
-        list.save
+        @list.name = expected_new_name
+        @list.save
       end
     end
 
@@ -59,8 +58,28 @@ module Trello
       end
     end
 
-    it "is not closed" do
-      @list.closed?.should_not be_true
+    describe "#closed?" do
+      it "returns the closed attribute" do
+        @list.closed?.should_not be_true
+      end
+    end
+
+    describe "#close" do
+      it "updates the close attribute to true" do
+        @list.close
+        @list.closed.should be_true
+      end
+    end
+
+    describe "#close!" do
+      it "updates the close attribute to true and saves the list" do
+        Client.should_receive(:put).once.with("/lists/abcdef123456789123456789", {
+          :name   => @list.name,
+          :closed => true
+        })
+
+        @list.close!
+      end
     end
   end
 end


### PR DESCRIPTION
For both `Card` and `List` models:
- `object#closed?` returns the `closed` attribute (already existed for `List` but without tests)
- `object#close` sets the `closed` attribute to `true`
- `object#close!` sets the `closed` attribute to `true` and PUT the object through Trello API
