### PR TITLE
BasicAuthPolicy doesn't carry forward any request body.

### DIFF
--- a/lib/trello/authorization.rb
+++ b/lib/trello/authorization.rb
@@ -16,7 +16,7 @@ module Trello
           new_values = { :key => @developer_public_key, :token => @member_token }
           the_uri.query_values = new_values.merge existing_values
 
-          Request.new request.verb, the_uri, request.headers
+          Request.new request.verb, the_uri, request.headers, request.body
         end
       end
     end


### PR DESCRIPTION
The BasicAuthPolicy sanitizer wasn't carrying forward any set request body, which meant that any API call to change a value that was using BasicAuth would fail.
