### PR TITLE
changed oauth url for token to correct one trello.com/1/authorize

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -15,7 +15,7 @@ require 'active_model'
 #   OAuthPolicy.consumer_credential = OAuthCredential.new 'PUBLIC_KEY', 'SECRET'
 #
 # You can get the key by going to this url in your browser:
-# https://trello.com/1/connect?key=PUBLIC_KEY_FROM_ABOVE&name=MyApp&response_type=token&scope=read,write,account&expiration=never
+# https://trello.com/1/authorize?key=PUBLIC_KEY_FROM_ABOVE&name=MyApp&response_type=token&scope=read,write,account&expiration=never
 # Only request the permissions you need; i.e., scope=read if you only need read, or scope=write if you only need write. Comma separate scopes you need.
 # If you want your token to expire after 30 days, drop the &expiration=never. Then run the following code, where KEY denotes the key returned from the
 # url above:

--- a/spec/integration/integration_test.rb
+++ b/spec/integration/integration_test.rb
@@ -16,7 +16,7 @@ module IntegrationTest
       before :all do
         # Getting developer/member key
         # 1. https://trello.com/1/appKey/generate
-        # 2. https://trello.com/1/connect?key=<public_key_here>&name=RubyTrelloIntegrationTests&response_type=token
+        # 2. https://trello.com/1/authorize?key=<public_key_here>&name=RubyTrelloIntegrationTests&response_type=token
         # See: https://trello.com/board/trello-public-api/4ed7e27fe6abb2517a21383d
 
         @developer_public_key = ENV["DEVELOPER_PUBLIC_KEY"]

--- a/test.rb
+++ b/test.rb
@@ -12,7 +12,7 @@ Trello::Authorization.const_set :AuthPolicy, OAuthPolicy
 OAuthPolicy.consumer_credential = OAuthCredential.new 'PUBLIC_KEY', 'SECRET'
 # First arg is the access token key, second is presently not used -- trello bug?
 # You can get the key by going to this url in your browser:
-# https://trello.com/1/connect?key=PUBLIC_KEY_FROM_ABOVE&name=MyApp&response_type=token&scope=read,write,account&expiration=never
+# https://trello.com/1/authorize?key=PUBLIC_KEY_FROM_ABOVE&name=MyApp&response_type=token&scope=read,write,account&expiration=never
 # Only request the permissions you need; i.e., scope=read if you only need read, or scope=write if you only need write. Comma separate scopes you need.
 # If you want your token to expire after 30 days, drop the &expiration=never.
 OAuthPolicy.token = OAuthCredential.new 'ACCESS_TOKEN_KEY', nil


### PR DESCRIPTION
Updated documentation for url used to get oauth token to point to the correct one.

trello.com/1/connect no longer works, should be trello.com/1/authorize according to documentation.

https://trello.com/docs/gettingstarted/index.html#getting-a-token-from-a-user
