### PR TITLE
remove test that never worked

### DIFF
--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -237,18 +237,7 @@ module Trello
         @card.add_attachment(f)
 
         @card.errors.should be_empty
-
       end
-
-      it "can add another attachment" do
-        f = File.new('spec/list_spec.rb', 'r')
-        card = Card.new(cards_details.first)
-        before_count = card.attachments.count
-        card.add_attachment(f)
-        after_count = card.attachments.count
-        after_count.should be > before_count
-      end
-
 
       it "can list the existing attachments" do
         Client.stub(:get).with("/boards/abcdef123456789123456789").and_return JSON.generate(boards_details.first)


### PR DESCRIPTION
The test for multiple attachments was added in e4ff0d959a0020faf5da7a1acce1840f3c3ff826 but simply never worked. It looks like this test was started and then abandoned before it was finished (it isn't stubbing the Client calls, for instance, like the other attachment specs do).

If this test is removed and #31 is merged then the test suite should be green again.

Making this test work as originally intended is pretty involved but, if you'd like, I'm happy to delete the failing parts and leave the test pending.
