### PR TITLE
fixes board update! method

### DIFF
--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -42,9 +42,9 @@ module Trello
       @changed_attributes.clear
 
       Client.put("/boards/#{self.id}/", {
-        :name        => @name,
-        :description => @description,
-        :closed      => @closed
+        :name        => attributes[:name],
+        :description => attributes[:description],
+        :closed      => attributes[:closed]
       }).json_into(self)
     end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -178,6 +178,29 @@ module Trello
     it "saves OR updates depending on whether or not it has an id set"
   end
 
+  describe '#update!' do
+    include Helpers
+
+    let(:any_board_json) do
+      JSON.generate(boards_details.first)
+    end
+
+    it "puts basic attributes" do
+      board = Board.new 'id' => "board_id"
+
+      board.name        = "new name"
+      board.description = "new description"
+      board.closed      = true
+
+      Client.should_receive(:put).with("/boards/#{board.id}/", {
+        :name => "new name",
+        :description => "new description",
+        :closed => true
+      }).and_return any_board_json
+      board.update!
+    end
+  end
+
   describe "Repository" do
     include Helpers
 


### PR DESCRIPTION
I fixed the board update! method so that it worked. previously the ivars were never set so Trello would reject the put request, complaining about invalid (in this case nil) board name.

This also makes it so you can now close boards (see issue #28).
