### PR TITLE
Add list position to registered attributes

### DIFF
--- a/lib/trello/list.rb
+++ b/lib/trello/list.rb
@@ -1,7 +1,7 @@
 module Trello
   # A List is a container which holds cards. Lists are items on a board.
   class List < BasicData
-    register_attributes :id, :name, :closed, :board_id, :readonly => [ :id, :board_id ]
+    register_attributes :id, :name, :closed, :board_id, :pos, :readonly => [ :id, :board_id ]
     validates_presence_of :id, :name, :board_id
     validates_length_of   :name, :in => 1..16384
 
@@ -28,6 +28,7 @@ module Trello
       attributes[:name]     = fields['name']
       attributes[:closed]   = fields['closed']
       attributes[:board_id] = fields['idBoard']
+      attributes[:pos]      = fields['pos']
       self
     end
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -42,6 +42,10 @@ module Trello
       it "has a board" do
         @list.board.should == Board.new(boards_details.first)
       end
+
+      it "gets its position" do
+        @list.pos.should == lists_details.first['pos']
+      end
     end
 
     context "actions" do


### PR DESCRIPTION
It'd be useful to read the list's position available from the api: [https://trello.com/docs/api/list/index.html#get-1-lists-idlist-field](https://trello.com/docs/api/list/index.html#get-1-lists-idlist-field)
