### PR TITLE
Make specs compatible with ruby-head

### DIFF
--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -4,11 +4,11 @@ module Trello
   describe Card do
     include Helpers
 
+    let(:card) { Card.find('abcdef123456789123456789') }
+
     before(:each) do
       Client.stub(:get).with("/cards/abcdef123456789123456789").
         and_return JSON.generate(cards_details.first)
-
-      @card = Card.find('abcdef123456789123456789')
     end
 
     context "creating" do
@@ -54,7 +54,7 @@ module Trello
         }
 
         Client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)
-        card = @card.dup
+
         card.name = expected_new_name
         card.save
       end
@@ -62,81 +62,81 @@ module Trello
 
     context "fields" do
       it "gets its id" do
-        @card.id.should_not be_nil
+        card.id.should_not be_nil
       end
 
       it "gets its short id" do
-        @card.short_id.should_not be_nil
+        card.short_id.should_not be_nil
       end
 
       it "gets its name" do
-        @card.name.should_not be_nil
+        card.name.should_not be_nil
       end
 
       it "gets its description" do
-        @card.description.should_not be_nil
+        card.description.should_not be_nil
       end
 
       it "knows if it is open or closed" do
-        @card.closed.should_not be_nil
+        card.closed.should_not be_nil
       end
 
       it "gets its url" do
-        @card.url.should_not be_nil
+        card.url.should_not be_nil
       end
     end
 
     context "actions" do
       it "asks for all actions by default" do
         Client.stub(:get).with("/cards/abcdef123456789123456789/actions", { :filter => :all }).and_return actions_payload
-        @card.actions.count.should be > 0
+        card.actions.count.should be > 0
       end
 
       it "allows overriding the filter" do
         Client.stub(:get).with("/cards/abcdef123456789123456789/actions", { :filter => :updateCard }).and_return actions_payload
-        @card.actions(:filter => :updateCard).count.should be > 0
+        card.actions(:filter => :updateCard).count.should be > 0
       end
     end
 
     context "boards" do
       it "has a board" do
         Client.stub(:get).with("/boards/abcdef123456789123456789").and_return JSON.generate(boards_details.first)
-        @card.board.should_not be_nil
+        card.board.should_not be_nil
       end
     end
 
     context "checklists" do
       it "has a list of checklists" do
         Client.stub(:get).with("/cards/abcdef123456789123456789/checklists", { :filter => :all }).and_return checklists_payload
-        @card.checklists.count.should be > 0
+        card.checklists.count.should be > 0
       end
     end
 
     context "list" do
       it 'has a list' do
         Client.stub(:get).with("/lists/abcdef123456789123456789").and_return JSON.generate(lists_details.first)
-        @card.list.should_not be_nil
+        card.list.should_not be_nil
       end
 
       it 'can be moved to another list' do
         other_list = stub(:id => '987654321987654321fedcba')
         payload = {:value => other_list.id}
         Client.should_receive(:put).with("/cards/abcdef123456789123456789/idList", payload)
-        @card.move_to_list(other_list)
+        card.move_to_list(other_list)
       end
 
       it 'should not be moved if new list is identical to old list' do
         other_list = stub(:id => 'abcdef123456789123456789')
         payload = {:value => other_list.id}
         Client.should_not_receive(:put)
-        @card.move_to_list(other_list)
+        card.move_to_list(other_list)
       end
 
       it 'can be moved to another board' do
         other_board = stub(:id => '987654321987654321fedcba')
         payload = {:value => other_board.id}
         Client.should_receive(:put).with("/cards/abcdef123456789123456789/idBoard", payload)
-        @card.move_to_board(other_board)
+        card.move_to_board(other_board)
       end
 
       it 'can be moved to a list on another board' do
@@ -144,13 +144,13 @@ module Trello
         other_list = stub(:id => '987654321987654321aalist')
         payload = {:value => other_board.id, :idList => other_list.id}
         Client.should_receive(:put).with("/cards/abcdef123456789123456789/idBoard", payload)
-        @card.move_to_board(other_board, other_list)
+        card.move_to_board(other_board, other_list)
       end
 
       it 'should not be moved if new board is identical with old board', :focus => true do
         other_board = stub(:id => 'abcdef123456789123456789')
         Client.should_not_receive(:put)
-        @card.move_to_board(other_board)
+        card.move_to_board(other_board)
       end
     end
 
@@ -159,8 +159,8 @@ module Trello
         Client.stub(:get).with("/boards/abcdef123456789123456789").and_return JSON.generate(boards_details.first)
         Client.stub(:get).with("/members/abcdef123456789123456789").and_return user_payload
 
-        @card.board.should_not be_nil
-        @card.members.should_not be_nil
+        card.board.should_not be_nil
+        card.members.should_not be_nil
       end
 
       it "allows a member to be added to a card" do
@@ -169,13 +169,13 @@ module Trello
           :value => new_member.id
         }
         Client.should_receive(:post).with("/cards/abcdef123456789123456789/members", payload)
-        @card.add_member(new_member)
+        card.add_member(new_member)
       end
 
       it "allows a member to be removed from a card" do
         existing_member = stub(:id => '4ee7df3ce582acdec80000b2')
         Client.should_receive(:delete).with("/cards/abcdef123456789123456789/members/#{existing_member.id}")
-        @card.remove_member(existing_member)
+        card.remove_member(existing_member)
       end
     end
 
@@ -185,7 +185,7 @@ module Trello
           with("/cards/abcdef123456789123456789/actions/comments", { :text => 'testing' }).
           and_return JSON.generate(boards_details.first)
 
-        @card.add_comment "testing"
+        card.add_comment "testing"
       end
     end
 
@@ -193,7 +193,7 @@ module Trello
       it "can retrieve labels" do
         Client.stub(:get).with("/cards/abcdef123456789123456789/labels").
           and_return label_payload
-        labels = @card.labels
+        labels = card.labels
         labels.size.should == 2
 
         labels[0].color.should == 'yellow'
@@ -206,29 +206,29 @@ module Trello
       it "can add a label" do
         Client.stub(:post).with("/cards/abcdef123456789123456789/labels", { :value => 'green' }).
           and_return "not important"
-        @card.add_label('green')
-        @card.errors.should be_empty
+        card.add_label('green')
+        card.errors.should be_empty
       end
 
       it "can remove a label" do
         Client.stub(:delete).with("/cards/abcdef123456789123456789/labels/green").
           and_return "not important"
-        @card.remove_label('green')
-        @card.errors.should be_empty
+        card.remove_label('green')
+        card.errors.should be_empty
       end
 
       it "throws an error when trying to add a label with an unknown colour" do
         Client.stub(:post).with("/cards/abcdef123456789123456789/labels", { :value => 'green' }).
           and_return "not important"
-        @card.add_label('mauve')
-        @card.errors.full_messages.to_sentence.should == "Label colour 'mauve' does not exist"
+        card.add_label('mauve')
+        card.errors.full_messages.to_sentence.should == "Label colour 'mauve' does not exist"
       end
 
       it "throws an error when trying to remove a label with an unknown colour" do
         Client.stub(:delete).with("/cards/abcdef123456789123456789/labels/mauve").
           and_return "not important"
-        @card.remove_label('mauve')
-        @card.errors.full_messages.to_sentence.should == "Label colour 'mauve' does not exist"
+        card.remove_label('mauve')
+        card.errors.full_messages.to_sentence.should == "Label colour 'mauve' does not exist"
       end
     end
 
@@ -240,17 +240,17 @@ module Trello
               { :file => f, :name => ''  }).
               and_return "not important"
 
-        @card.add_attachment(f)
+        card.add_attachment(f)
 
-        @card.errors.should be_empty
+        card.errors.should be_empty
       end
 
       it "can list the existing attachments" do
         Client.stub(:get).with("/boards/abcdef123456789123456789").and_return JSON.generate(boards_details.first)
         Client.stub(:get).with("/cards/abcdef123456789123456789/attachments").and_return attachments_payload
 
-        @card.board.should_not be_nil
-        @card.attachments.should_not be_nil
+        card.board.should_not be_nil
+        card.attachments.should_not be_nil
       end
 
       it "can remove an attachment" do
@@ -258,21 +258,21 @@ module Trello
           and_return "not important"
         Client.stub(:get).with("/cards/abcdef123456789123456789/attachments").and_return attachments_payload
 
-        @card.remove_attachment(@card.attachments.first)
-        @card.errors.should be_empty
+        card.remove_attachment(card.attachments.first)
+        card.errors.should be_empty
       end
     end
 
     describe "#closed?" do
       it "returns the closed attribute" do
-        @card.closed?.should_not be_true
+        card.closed?.should_not be_true
       end
     end
 
     describe "#close" do
       it "updates the close attribute to true" do
-        @card.close
-        @card.closed.should be_true
+        card.close
+        card.closed.should be_true
       end
     end
 
@@ -284,7 +284,7 @@ module Trello
 
         Client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)
 
-        @card.close!
+        card.close!
       end
     end
 

--- a/spec/checklist_spec.rb
+++ b/spec/checklist_spec.rb
@@ -4,11 +4,11 @@ module Trello
   describe Checklist do
     include Helpers
 
+    let(:checklist) { Checklist.find('abcdef123456789123456789') }
+
     before(:each) do
       Client.stub(:get).with("/checklists/abcdef123456789123456789").
         and_return JSON.generate(checklists_details.first)
-
-      @checklist = Checklist.find('abcdef123456789123456789')
     end
 
     context "creating" do
@@ -33,14 +33,14 @@ module Trello
     context "updating" do
       it "updating name does a put on the correct resource with the correct value" do
         expected_new_name = "xxx"
-        expected_resource = "/checklists/#{@checklist.id}"
+        expected_resource = "/checklists/abcdef123456789123456789"
         payload = {
           :name      => expected_new_name
         }
 
         result = JSON.generate(checklists_details.first)
         Client.should_receive(:put).once.with("/checklists/abcdef123456789123456789", payload).and_return result
-        checklist = @checklist.dup
+
         checklist.name = expected_new_name
         checklist.save
       end


### PR DESCRIPTION
This should address the [failing ruby-head build](https://travis-ci.org/jeremytregunna/ruby-trello/jobs/4112926). Addresses incompatibility between ruby-2.0 and the activemodel dependency, which [calls #initialize_dup as a public method](https://github.com/rails/rails/blob/3-2-stable/activemodel/lib/active_model/validations.rb#L179) (now private in ruby-head).

Rather than mess with dependencies, I opted to rewrite the failing specs so they don't rely on `dup`.
