### PR TITLE
Replace usage of #delegate with Forwardable

### DIFF
--- a/lib/trello/association_proxy.rb
+++ b/lib/trello/association_proxy.rb
@@ -2,12 +2,12 @@ require 'active_support/core_ext'
 
 module Trello
   class AssociationProxy
+    extend Forwardable
     alias :proxy_extend :extend
 
     instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|object_id|to_a)$|^__|^respond_to|proxy_/ }
 
-    delegate :owner, :target, :to => :@association
-    delegate :count,          :to => :@association
+    def_delegators :@association, :owner, :target, :count
 
     def initialize(association)
       @association = association

--- a/lib/trello/client.rb
+++ b/lib/trello/client.rb
@@ -2,10 +2,10 @@ require 'addressable/uri'
 
 module Trello
   class Client
+    extend Forwardable
     include Authorization
 
-    delegate *Configuration.configurable_attributes << { :to => :configuration }
-    delegate :credentials, :to => :configuration
+    def_delegators :configuration, :credentials, *Configuration.configurable_attributes
 
     def initialize(attrs = {})
       self.configuration.attributes = attrs

--- a/lib/trello/multi_association.rb
+++ b/lib/trello/multi_association.rb
@@ -1,6 +1,8 @@
 module Trello
   class MultiAssociation < Association
-    delegate :count, :to => :target
+    extend Forwardable
+
+    def_delegator :target, :count
 
     def initialize(owner, target = [])
       super


### PR DESCRIPTION
I'm not completely sure where `#delegate` is coming from (looks like Rails ?) but at least for me it doesn't work in a pure Ruby 1.9.3 MRI environment.

This PR replaces all usages of `#delegate` with `Forwardable#def_delegator` or `#def_delegators`
