### PR TITLE
Running the most basic example fails with uninitialized constant

### DIFF
--- a/lib/trello/client.rb
+++ b/lib/trello/client.rb
@@ -1,4 +1,5 @@
 require 'addressable/uri'
+require 'forwardable'
 
 module Trello
   class Client


### PR DESCRIPTION
`class:Client': uninitialized constant Forwardable (NameError)
