### PR TITLE
Use HTTPS_PROXY environment variable

### DIFF
--- a/lib/trello/net.rb
+++ b/lib/trello/net.rb
@@ -24,7 +24,7 @@ module Trello
       def execute_core(request)
         require "rest_client"
         
-        RestClient.proxy = ENV['HTTP_PROXY'] if ENV['HTTP_PROXY']
+        RestClient.proxy = ENV['HTTP_PROXYS'] if ENV['HTTP_PROXYS']
         RestClient::Request.execute(
           :method => request.verb, 
           :url => request.uri.to_s, 


### PR DESCRIPTION
The Trello API uses the https protocol, so the gem should
use the https proxy environment variable accordingly.
