### PR TITLE
add missing 'email' field for Member

### DIFF
--- a/lib/trello/member.rb
+++ b/lib/trello/member.rb
@@ -1,7 +1,7 @@
 module Trello
   # A Member is a user of the Trello service.
   class Member < BasicData
-    register_attributes :id, :username, :full_name, :avatar_id, :bio, :url, :readonly => [ :id, :username, :avatar_id, :url ]
+    register_attributes :id, :username, :email, :full_name, :avatar_id, :bio, :url, :readonly => [ :id, :username, :avatar_id, :url ]
     validates_presence_of :id, :username
     validates_length_of   :full_name, :minimum => 4
     validates_length_of   :bio,       :maximum => 16384
@@ -24,6 +24,7 @@ module Trello
     def update_fields(fields)
       attributes[:id]        = fields['id']
       attributes[:full_name] = fields['fullName']
+      attributes[:email]     = fields['email']
       attributes[:username]  = fields['username']
       attributes[:avatar_id] = fields['avatarHash']
       attributes[:bio]       = fields['bio']

--- a/spec/member_spec.rb
+++ b/spec/member_spec.rb
@@ -89,6 +89,10 @@ module Trello
       it "gets the username" do
         member.username.should == user_details['username']
       end
+
+      it "gets the email" do
+        member.email.should == user_details['email']
+      end
     end
 
     context "modification" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,8 @@ module Helpers
       "username"   => "me",
       "avatarHash" => "abcdef1234567890abcdef1234567890",
       "bio"        => "a rather dumb user",
-      "url"        => "https://trello.com/me"
+      "url"        => "https://trello.com/me",
+      "email"      => "johnsmith@example.com"
     }
   end
 


### PR DESCRIPTION
email field is available in the /members API call if 'account' scope is requested in the authorization phase
