### PR TITLE
Throw configuration error on generic auth policy

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -71,9 +71,13 @@ module Trello
   API_VERSION = 1
 
   # Raise this when we hit a Trello error.
-  class Error < StandardError; end
+  Error = Class.new(StandardError)
+
   # This specific error is thrown when your access token is invalid. You should get a new one.
-  class InvalidAccessToken < StandardError; end
+  InvalidAccessToken = Class.new(Error)
+
+  # This error is thrown when your client has not been configured
+  ConfigurationError = Class.new(Error)
 
   def self.logger
     @logger ||= Logger.new(STDOUT)

--- a/lib/trello/authorization.rb
+++ b/lib/trello/authorization.rb
@@ -6,6 +6,10 @@ module Trello
 
     AuthPolicy = Class.new do
       def initialize(attrs = {}); end
+
+      def authorize(*args)
+        raise Trello::ConfigurationError, "Trello has not been configured to make authorized requests."
+      end
     end
 
     class BasicAuthPolicy

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -69,5 +69,15 @@ describe Trello do
         auth_policy.oauth_token_secret.should be_nil
       end
     end
+
+    context "not configured" do
+      before do
+        Trello.configure
+      end
+
+      it { Trello.auth_policy.should be_a(AuthPolicy) }
+      it { expect { Trello.client.get(:member) }.to raise_error(Trello::ConfigurationError) }
+    end
+
   end
 end


### PR DESCRIPTION
Attempts to provide useful feedback if `Trello` has not been successfully configured with an expected auth policy.
