### PR TITLE
Adding checked and postion options to checklist add item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin
 .bundle
 vendor/bundle
 Gemfile.lock
+.project

--- a/lib/trello/checklist.rb
+++ b/lib/trello/checklist.rb
@@ -77,8 +77,8 @@ module Trello
     end
 
     # Add an item to the checklist
-    def add_item(name)
-      client.post("/checklists/#{id}/checkItems", {:name => name})
+    def add_item(name, checked=false, position='bottom')
+      client.post("/checklists/#{id}/checkItems", {:name => name, :checked => checked, :pos => position})
     end
 
     # Delete a checklist item

--- a/lib/trello/item.rb
+++ b/lib/trello/item.rb
@@ -1,7 +1,7 @@
 module Trello
   # An Item is a basic task that can be checked off and marked as completed.
   class Item < BasicData
-    register_attributes :id, :name, :type, :readonly => [ :id, :name, :type ]
+    register_attributes :id, :name, :type, :state, :pos, :readonly => [ :id, :name, :type, :state, :pos ]
     validates_presence_of :id, :type
 
     # Updates the fields of an item.
@@ -9,9 +9,11 @@ module Trello
     # Supply a hash of string keyed data retrieved from the Trello API representing
     # an item.
     def update_fields(fields)
-      attributes[:id]   = fields['id']
-      attributes[:name] = fields['name']
-      attributes[:type] = fields['type']
+      attributes[:id]    = fields['id']
+      attributes[:name]  = fields['name']
+      attributes[:type]  = fields['type']
+      attributes[:state] = fields['state']
+      attributes[:pos]   = fields['pos']
       self
     end
   end

--- a/spec/checklist_spec.rb
+++ b/spec/checklist_spec.rb
@@ -75,6 +75,27 @@ module Trello
         checklist.name = expected_new_name
         checklist.save
       end
+
+      it "adds an item" do
+        expected_item_name = "item1"
+        expected_checked = true
+        expected_pos = 9999
+        expected_resource = "/checklists/abcdef123456789123456789"
+        payload = {
+            :name => expected_item_name,
+            :checked => expected_checked,
+            :pos => expected_pos
+        }
+        result_hash = {
+            :name => expected_item_name,
+            :state => expected_checked ? 'complete' : 'incomplete',
+            :pos => expected_pos
+        }
+        result = JSON.generate(result_hash)
+        client.should_receive(:post).once.with("/checklists/abcdef123456789123456789/checkItems", payload).and_return result
+
+        checklist.add_item(expected_item_name, expected_checked, expected_pos)
+      end
     end
 
     context "board" do

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -6,7 +6,9 @@ module Trello
       @detail = {
         'id'   => "abcdef123456789123456789",
         'name' => "test item",
-        'type' => "check"
+        'type' => "check",
+        'state' => "complete",
+        'pos' => 0
       }
 
       @item = Item.new(@detail)
@@ -22,6 +24,14 @@ module Trello
 
     it "knows its type" do
       @item.type.should == @detail['type']
+    end
+
+    it "knows its state" do
+      @item.state.should == @detail['state']
+    end
+
+    it "knows its pos" do
+      @item.pos.should == @detail['pos']
     end
   end
 end


### PR DESCRIPTION
Trello doesn't have the ability (at least that I can find in the api) to check an existing item but they at least can let you add an item in the checked state.  Adding position as a bonus.
