### PR TITLE
Relax active model dependency and add 3.2.0 and edge active model versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
   - 2.0.0
   - jruby-19mode
   - rbx-2.1.1
+env:
+  - ACTIVE_MODEL_VERSION='~> 3.2.0'
+  - ACTIVE_MODEL_VERSION='~> 4.0'
 gemfile: Gemfile
 notifications:
   recipients:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+if active_model_version = ENV['ACTIVE_MODEL_VERSION']
+  gem 'activemodel', active_model_version
+end
+
 gemspec
 
 group :development, :spec do

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency 'activemodel', '~> 3.2.0'
+  s.add_dependency 'activemodel', '>= 3.2.0'
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json'
   s.add_dependency 'oauth',       '~> 0.4.5'


### PR DESCRIPTION
Hi,
Just a small update to the gemspec so it can be installed with the latest version of activemodel.
