### PR TITLE
Fetches cover image for card

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -41,6 +41,7 @@ module Trello
   autoload :Association,       'trello/association'
   autoload :AssociationProxy,  'trello/association_proxy'
   autoload :Attachment,        'trello/attachment'
+  autoload :CoverImage,        'trello/cover_image'
   autoload :BasicData,         'trello/basic_data'
   autoload :Board,             'trello/board'
   autoload :Card,              'trello/card'

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -1,7 +1,8 @@
 module Trello
   # A Card is a container that can house checklists and comments; it resides inside a List.
   class Card < BasicData
-    register_attributes :id, :short_id, :name, :desc, :due, :closed, :url, :board_id, :member_ids, :list_id, :pos, :last_activity_date, :card_labels,
+    register_attributes :id, :short_id, :name, :desc, :due, :closed, :url, :board_id,
+      :member_ids, :list_id, :pos, :last_activity_date, :card_labels, :cover_image_id,
       :readonly => [ :id, :short_id, :url, :last_activity_date ]
     validates_presence_of :id, :name, :list_id
     validates_length_of   :name,        :in => 1..16384
@@ -19,6 +20,7 @@ module Trello
       url: 'url',
       board_id: 'idBoard',
       member_ids: 'idMembers',
+      cover_image_id: 'idAttachmentCover',
       list_id: 'idList',
       pos: 'pos',
       last_activity_date: 'dateLastActivity',
@@ -61,11 +63,14 @@ module Trello
       attributes[:pos]                = fields[SYMBOL_TO_STRING[:post]]
       attributes[:card_labels]        = fields[SYMBOL_TO_STRING[:card_labels]]
       attributes[:last_activity_date] = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil
+      attributes[:cover_image_id]     = fields[SYMBOL_TO_STRING[:cover_image_id]]
       self
     end
 
     # Returns a reference to the board this card is part of.
     one :board, :path => :boards, :using => :board_id
+    # Returns a reference to the cover image attachment
+    one :cover_image, :path => :attachments, :using => :cover_image_id
 
     # Returns a list of checklists associated with the card.
     #

--- a/lib/trello/cover_image.rb
+++ b/lib/trello/cover_image.rb
@@ -1,0 +1,8 @@
+module Trello
+  # The trello cover image
+  #
+  # This is normally an attachment that the user (or trello) has set
+  # as the cover image
+  class CoverImage < Attachment
+  end
+end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -111,6 +111,10 @@ module Trello
       it "gets its last active date" do
         card.last_activity_date.should_not be_nil
       end
+
+      it "gets its cover image id" do
+        card.cover_image_id.should_not be_nil
+      end
     end
 
     context "actions" do
@@ -129,6 +133,13 @@ module Trello
       it "has a board" do
         client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
         card.board.should_not be_nil
+      end
+    end
+
+    context "cover image" do
+      it "has a cover image" do
+        client.stub(:get).with("/attachments/abcdef123456789123456789", {}).and_return JSON.generate(attachments_details.first)
+        card.cover_image.should_not be_nil
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,7 @@ module Helpers
       'closed'            => false,
       'idList'            => 'abcdef123456789123456789',
       'idBoard'           => 'abcdef123456789123456789',
+      'idAttachmentCover' => 'abcdef123456789123456789',
       'idMembers'         => ['abcdef123456789123456789'],
       'url'               => 'https://trello.com/card/board/specify-the-type-and-scope-of-the-jit-in-a-lightweight-spec/abcdef123456789123456789/abcdef123456789123456789',
       'pos'               => 12,


### PR DESCRIPTION
Trello introduced the cover image feature a while ago and while the cover image is always one of the attachment there is no way to know which one if there are multiple attachments.

The Trello API provided `idCoverAttachment` which points to the attachment that serves as the cover id. This commit also provided a `#cover_image` method for `Trello::Card` that returns the cover image attachment.
