### PR TITLE
Complete an example with a `require`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ illustrate that future versions may include ruby 1.9.3+ specific features.
 Basic authorization
 
 ```ruby
+require 'trello'
+
 Trello.configure do |config|
   config.developer_public_key = TRELLO_DEVELOPER_PUBLIC_KEY
   config.member_token = TRELLO_MEMBER_TOKEN


### PR DESCRIPTION
Since my first move was to do a `require 'ruby-trello'`…
