### PR TITLE
fix mapping of pos argument

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -65,7 +65,7 @@ module Trello
       attributes[:board_id]           = fields[SYMBOL_TO_STRING[:board_id]]
       attributes[:member_ids]         = fields[SYMBOL_TO_STRING[:member_ids]]
       attributes[:list_id]            = fields[SYMBOL_TO_STRING[:list_id]]
-      attributes[:pos]                = fields[SYMBOL_TO_STRING[:post]]
+      attributes[:pos]                = fields[SYMBOL_TO_STRING[:pos]]
       attributes[:card_labels]        = fields[SYMBOL_TO_STRING[:card_labels]]
       attributes[:last_activity_date] = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil
       attributes[:cover_image_id]     = fields[SYMBOL_TO_STRING[:cover_image_id]]

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -119,6 +119,10 @@ module Trello
       it "gets its cover image id" do
         card.cover_image_id.should_not be_nil
       end
+
+      it "gets its pos" do
+        card.pos.should_not be_nil
+      end
     end
 
     context "actions" do


### PR DESCRIPTION
The `pos` argument of the trello card was mapped to `post`. I fixed the spelling error and added a test spec.
