### PR TITLE
Added ability to update organization id on an existing board

### DIFF
--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -45,9 +45,10 @@ module Trello
       @changed_attributes.clear
 
       client.put("/boards/#{self.id}/", {
-        :name        => attributes[:name],
-        :description => attributes[:description],
-        :closed      => attributes[:closed]
+        :name           => attributes[:name],
+        :description    => attributes[:description],
+        :closed         => attributes[:closed],
+        :idOrganization => attributes[:organization_id]
       }).json_into(self)
     end
 


### PR DESCRIPTION
While boards supported organization_id, they were not properly updated on existing boards.
