### PR TITLE
gitignoring /doc and /.yardoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ vendor/bundle
 Gemfile.lock
 .project
 .DS_Store
+
+/doc
+/.yardoc


### PR DESCRIPTION
There's no need to include these in the git repo as people can (and should) generate them themselves using the `yardoc` command.