### PR TITLE
Add new labels to board

### DIFF
--- a/lib/trello/label_name.rb
+++ b/lib/trello/label_name.rb
@@ -2,7 +2,7 @@ module Trello
 
   # A colored Label attached to a card
   class LabelName < BasicData
-    register_attributes :yellow, :red, :orange, :green, :purple, :blue
+    register_attributes :yellow, :red, :orange, :green, :purple, :blue, :sky, :pink, :lime, :black
 
     # Update the fields of a label.
     #
@@ -15,6 +15,11 @@ module Trello
       attributes[:green] = fields['green']
       attributes[:purple] = fields['purple']
       attributes[:blue] = fields['blue']
+      attributes[:sky] = fields['sky']
+      attributes[:pink] = fields['pink']
+      attributes[:lime] = fields['lime']
+      attributes[:black] = fields['black']
+
       self
     end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -82,7 +82,7 @@ module Trello
         client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
           and_return label_name_payload
 
-        board.labels.count.should eq(6)
+        board.labels.count.should eq(10)
       end
     end
 


### PR DESCRIPTION
Fixing more of issue #113 

this will fix the `board#labels` method and anything else that uses the `label_name` class.