### PR TITLE
Implements new trello label api

### DIFF
--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -106,8 +106,12 @@ module Trello
     # Returns a reference to the organization this board belongs to.
     one :organization, path: :organizations, using: :organization_id
 
-    def labels
-      labels = client.get("/boards/#{id}/labelnames").json_into(LabelName)
+    def labels names=true
+      if names
+        labels = client.get("/boards/#{id}/labelnames").json_into(LabelName)
+      else
+        labels = client.get("/boards/#{id}/labels").json_into(Label)
+      end
       MultiAssociation.new(self, labels).proxy
     end
 

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -210,26 +210,26 @@ module Trello
       labels = client.get("/cards/#{id}/labels").json_into(Label)
       MultiAssociation.new(self, labels).proxy
     end
-
-    # Label colours
-    def label_colours
-      %w{green yellow orange red purple blue sky lime pink black}
-    end
     
     # Add a label
-    def add_label(colour)
-      unless label_colours.include? colour
-        errors.add(:label, "colour '#{colour}' does not exist")
-        return Trello.logger.warn "The label colour '#{colour}' does not exist."
+    def add_label(value)
+      if value.is_a? String
+        colour = value 
+        unless Label.label_colours.include? colour
+          errors.add(:label, "colour '#{colour}' does not exist")
+          return Trello.logger.warn "The label colour '#{colour}' does not exist."
+        end
+        client.post("/cards/#{id}/labels", { value: colour })
+      elsif value.is_a? Label
+        client.post("/cards/#{id}/idLabels", {value: value.id})
       end
-      client.post("/cards/#{id}/labels", { value: colour })
     end
 
     # Remove a label
     def remove_label(colour)
-      unless label_colours.include? colour
+      unless Label.label_colours.include? colour
         errors.add(:label, "colour '#{colour}' does not exist")
-        return Trello.logger.warn "The label colour '#{colour}' does not exist." unless label_colours.include? colour
+        return Trello.logger.warn "The label colour '#{colour}' does not exist." unless Label.label_colours.include? colour
       end
       client.delete("/cards/#{id}/labels/#{colour}")
     end

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -226,12 +226,17 @@ module Trello
     end
 
     # Remove a label
-    def remove_label(colour)
-      unless Label.label_colours.include? colour
-        errors.add(:label, "colour '#{colour}' does not exist")
-        return Trello.logger.warn "The label colour '#{colour}' does not exist." unless Label.label_colours.include? colour
+    def remove_label(value)
+      if value.is_a? String
+        colour = value 
+        unless Label.label_colours.include? colour
+          errors.add(:label, "colour '#{colour}' does not exist")
+          return Trello.logger.warn "The label colour '#{colour}' does not exist." unless Label.label_colours.include? colour
+        end
+        client.delete("/cards/#{id}/labels/#{colour}")
+      elsif value.is_a? Label
+        client.delete("/cards/#{id}/idLabels/#{value.id}")
       end
-      client.delete("/cards/#{id}/labels/#{colour}")
     end
 
     # Add an attachment to this card

--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -2,18 +2,100 @@ module Trello
 
   # A colored Label attached to a card
   class Label < BasicData
-    register_attributes :name, :color
+    register_attributes :id, :name, :board_id, :uses,
+      readonly: [ :id, :uses, :board_id ]
+    validates_presence_of :id, :uses, :board_id, :name
+    validates_length_of   :name,        in: 1..16384
+        
+    SYMBOL_TO_STRING = {
+      id: 'id',
+      name: 'name',
+      board_id: 'idBoard',
+      color: 'color',
+      uses: 'uses'
+    }
+
+    class << self
+      # Find a specific card by its id.
+      def find(id, params = {})
+        client.find(:label, id, params)
+      end
+
+      # Create a new card and save it on Trello.
+      def create(options)
+        client.create(:label,
+          'name' => options[:name],
+          'idBoard' => options[:board_id],
+          'color'   => options[:color],
+        )
+      end
+
+      # Label colours
+      def label_colours
+        %w{green yellow orange red purple blue sky lime pink black}
+      end
+    end
+
+    define_attribute_methods [:color]
+
+    def color
+      @attributes[:color]
+    end
+
+    def color= colour
+      unless Label.label_colours.include? colour
+        errors.add(:label, "color '#{colour}' does not exist")
+        return Trello.logger.warn "The label colour '#{colour}' does not exist."
+      end
+
+      self.send(:"color_will_change!") unless colour == @attributes[:color]
+      @attributes[:color] = colour
+    end
 
     # Update the fields of a label.
     #
     # Supply a hash of stringkeyed data retrieved from the Trello API representing
     # a label.
     def update_fields(fields)
+      attributes[:id] = fields['id']
       attributes[:name]  = fields['name']
       attributes[:color] = fields['color']
+      attributes[:board_id] = fields['idBoard']
+      attributes[:uses] = fields['uses']
       self
     end
 
-  end
+    # Returns a reference to the board this label is currently connected.
+    one :board, path: :boards, using: :board_id
 
+    # Saves a record.
+    def save
+      # If we have an id, just update our fields.
+      return update! if id
+
+      client.post("/labels", {
+        name:   name,
+        color:   color,
+        idBoard: board_id,
+      }).json_into(self)
+    end
+
+    # Update an existing record.
+    # Warning, this updates all fields using values already in memory. If
+    # an external resource has updated these fields, you should refresh!
+    # this object before making your changes, and before updating the record.
+    def update!
+      @previously_changed = changes
+      # extract only new values to build payload
+      payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
+      @changed_attributes.clear
+
+      client.put("/labels/#{id}", payload)
+    end
+
+    # Delete this card
+    def delete
+      client.delete("/labels/#{id}")
+    end
+  end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -79,9 +79,28 @@ module Trello
 
     context "labels" do
       it "gets the specific labels for the board" do
+        client.stub(:get).with("/boards/abcdef123456789123456789/labels").
+          and_return label_payload
+        labels = board.labels false
+        labels.count.should eq(4)
+
+
+        expect(labels[2].color).to  eq('red')
+        expect(labels[2].id).to  eq('abcdef123456789123456789')
+        expect(labels[2].board_id).to  eq('abcdef123456789123456789')
+        expect(labels[2].name).to  eq('deploy')
+        expect(labels[2].uses).to  eq(2)
+
+        expect(labels[3].color).to  eq('blue')
+        expect(labels[3].id).to  eq('abcdef123456789123456789')
+        expect(labels[3].board_id).to  eq('abcdef123456789123456789')
+        expect(labels[3].name).to  eq('on hold')
+        expect(labels[3].uses).to  eq(6)
+      end
+
+      it "gets the specific labels for the board" do
         client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
           and_return label_name_payload
-
         board.labels.count.should eq(6)
       end
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -284,6 +284,12 @@ module Trello
         expect(card.errors).to be_empty
       end
 
+      it "can remove a label instance" do
+        client.should_receive(:delete).once.with("/cards/abcdef123456789123456789/idLabels/abcdef123456789123456789")
+        label = Label.new(label_details.first)
+        card.remove_label(label)
+      end
+
       it "can add a label of any valid color" do
         %w(green yellow orange red purple blue sky lime pink black).each do |color|
           client.stub(:post).with("/cards/abcdef123456789123456789/labels", { :value => color }).

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -255,13 +255,19 @@ module Trello
         client.stub(:get).with("/cards/abcdef123456789123456789/labels").
           and_return label_payload
         labels = card.labels
-        expect(labels.size).to  eq(2)
+        expect(labels.size).to  eq(4)
 
         expect(labels[0].color).to  eq('yellow')
+        expect(labels[0].id).to  eq('abcdef123456789123456789')
+        expect(labels[0].board_id).to  eq('abcdef123456789123456789')
         expect(labels[0].name).to  eq('iOS')
+        expect(labels[0].uses).to  eq(3)
 
         expect(labels[1].color).to  eq('purple')
+        expect(labels[1].id).to  eq('abcdef123456789123456789')
+        expect(labels[1].board_id).to  eq('abcdef123456789123456789')
         expect(labels[1].name).to  eq('Issue or bug')
+        expect(labels[1].uses).to  eq(1)
       end
 
       it "can add a label" do
@@ -285,6 +291,12 @@ module Trello
           card.add_label(color)
           expect(card.errors).to be_empty
         end
+      end
+
+      it "can add a label instance" do
+        client.should_receive(:post).once.with("/cards/abcdef123456789123456789/idLabels", {:value => "abcdef123456789123456789"})
+        label = Label.new(label_details.first)
+        card.add_label label
       end
 
       it "throws an error when trying to add a label with an unknown colour" do

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+module Trello
+  describe Label do
+    include Helpers
+
+    let(:label) { client.find(:label, 'abcdef123456789123456789') }
+    let(:client) { Client.new }
+
+    before(:each) do
+      client.stub(:get).with("/labels/abcdef123456789123456789", {}).
+      and_return JSON.generate(label_details.first)
+    end
+
+    context "finding" do
+      let(:client) { Trello.client }
+
+      it "delegates to Trello.client#find" do
+        client.should_receive(:find).with(:label, 'abcdef123456789123456789', {})
+        Label.find('abcdef123456789123456789')
+      end
+
+      it "is equivalent to client#find" do
+        Label.find('abcdef123456789123456789').should eq(label)
+      end
+    end
+
+    context "creating" do
+      let(:client) { Trello.client }
+
+      it "creates a new record" do
+        label = Label.new(label_details.first)
+        label.should be_valid
+      end
+
+      it 'must not be valid if not given a name' do
+        label = Label.new('idBoard' => lists_details.first['board_id'])
+        label.should_not be_valid
+      end
+
+      it 'must not be valid if not given a board id' do
+        label = Label.new('name' => lists_details.first['name'])
+        label.should_not be_valid
+      end
+
+      it 'creates a new record and saves it on Trello', refactor: true do
+        payload = {
+          name: 'Test Label',
+          board_id: 'abcdef123456789123456789',
+        }
+
+        result = JSON.generate(cards_details.first.merge(payload.merge(idBoard: boards_details.first['id'])))
+
+        expected_payload = {name: "Test Label", color: nil, idBoard: "abcdef123456789123456789" }
+
+        client.should_receive(:post).with("/labels", expected_payload).and_return result
+
+        label = Label.create(label_details.first.merge(payload.merge(board_id: boards_details.first['id'])))
+
+        label.class.should be Label
+      end
+    end
+
+    context "updating" do
+      it "updating name does a put on the correct resource with the correct value" do
+        expected_new_name = "xxx"
+
+        payload = {
+          name: expected_new_name,
+        }
+
+        client.should_receive(:put).once.with("/labels/abcdef123456789123456789", payload)
+
+        label.name = expected_new_name
+        label.save
+      end
+
+      it "updating color does a put on the correct resource with the correct value" do
+        expected_new_color = "purple"
+
+        payload = {
+          color: expected_new_color,
+        }
+
+        client.should_receive(:put).once.with("/labels/abcdef123456789123456789", payload)
+
+        label.color = expected_new_color
+        label.save
+      end
+
+      it "can update with any valid color" do
+        %w(green yellow orange red purple blue sky lime pink black).each do |color|
+          client.stub(:put).with("/labels/abcdef123456789123456789", {color: color}).
+            and_return "not important"
+          label.color = color
+          label.save
+          expect(label.errors).to be_empty
+        end
+      end
+
+      it "throws an error when trying to update a label with an unknown colour" do
+        client.stub(:put).with("/labels/abcdef123456789123456789", {}).
+          and_return "not important"
+        label.color = 'mauve'
+        label.save
+        expect(label.errors.full_messages.to_sentence).to eq("Label color 'mauve' does not exist")
+      end
+    end
+
+    context "deleting" do
+      it "deletes the label" do
+        client.should_receive(:delete).with("/labels/#{label.id}")
+        label.delete
+      end
+    end
+
+    context "fields" do
+      it "gets its id" do
+        label.id.should_not be_nil
+      end
+
+      it "gets its name" do
+        label.name.should_not be_nil
+      end
+
+      it "gets its usage" do
+        label.uses.should_not be_nil
+      end
+
+      it "gets its color" do
+        label.color.should_not be_nil
+      end
+    end
+
+    context "boards" do
+      it "has a board" do
+        client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
+        label.board.should_not be_nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -274,28 +274,15 @@ module Helpers
 
   def label_details
     [
-      {'color' => 'yellow', 'name' => 'iOS'},
-      {'color' => 'purple', 'name' => 'Issue or bug'}
+      {'color' => 'yellow', 'name' => 'iOS', 'id' => 'abcdef123456789123456789', 'uses' => 3, 'idBoard' => 'abcdef123456789123456789'},
+      {'color' => 'purple', 'name' => 'Issue or bug', 'id' => 'abcdef123456789123456789', 'uses' => 1, 'idBoard' => 'abcdef123456789123456789'},
+      {'color' => 'red', 'name' => 'deploy', 'id' => 'abcdef123456789123456789', 'uses' => 2, 'idBoard' => 'abcdef123456789123456789'},
+      {'color' => 'blue', 'name' => 'on hold', 'id' => 'abcdef123456789123456789', 'uses' => 6, 'idBoard' => 'abcdef123456789123456789'}
     ]
   end
 
   def label_payload
     JSON.generate(label_details)
-  end
-
-  def label_name_details
-    [
-      {'yellow' => 'bug'},
-      {'red' => 'urgent'},
-      {'green' => 'deploy'},
-      {'blue' => 'on hold'},
-      {'orange' => 'new feature'},
-      {'purple' => 'experimental'}
-    ]
-  end
-
-  def label_name_payload
-    JSON.generate(label_name_details)
   end
 
   def webhooks_details
@@ -308,6 +295,21 @@ module Helpers
        'active'      => true
      }
     ]
+  end
+
+  def label_name_details
+  [
+    {'yellow' => 'bug'},
+    {'red' => 'urgent'},
+    {'green' => 'deploy'},
+    {'blue' => 'on hold'},
+    {'orange' => 'new feature'},
+    {'purple' => 'experimental'}
+  ]
+  end
+
+  def label_name_payload
+    JSON.generate(label_name_details)
   end
 
   def webhooks_payload


### PR DESCRIPTION
The number of labels attached to a board or card is no longer fixed. The
trello web api supports a few new calls to read, set and update those
labels. This commit reflects these changes in the classes:

- `Trello::Label`
- `Trello::Card`
- `Trello::Board`

The changes are suposed to be backward compatible.