### PR TITLE
Copy a checklist

### DIFF
--- a/lib/trello/checklist.rb
+++ b/lib/trello/checklist.rb
@@ -112,5 +112,19 @@ module Trello
     def delete
       client.delete("/checklists/#{id}")
     end
+
+    # Copy a checklist (i.e., same attributes, items, etc.)
+    def copy
+      checklist_copy = self.class.create(name: self.name, board_id: self.board_id)
+      copy_items_to(checklist_copy)
+      return checklist_copy
+    end
+
+    private
+    def copy_items_to(another_checklist)
+      items.each do |item|
+        another_checklist.add_item(item.name, item.complete?)
+      end
+    end
   end
 end

--- a/lib/trello/item.rb
+++ b/lib/trello/item.rb
@@ -27,5 +27,9 @@ module Trello
       attributes[:pos]   = fields['pos']
       self
     end
+
+    def complete?
+      state == "complete"
+    end
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -33,5 +33,17 @@ module Trello
     it 'knows its pos' do
       @item.pos.should == @detail['pos']
     end
+
+    describe '#complete?' do
+      it "knows when it is complete" do
+        allow(@item).to receive(:state).and_return "complete"
+        expect(@item).to be_complete
+      end
+
+      it "knowns when it is not complete" do
+        allow(@item).to receive(:state).and_return "incomplete"
+        expect(@item).to_not be_complete
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,25 @@ module Helpers
     JSON.generate(checklists_details)
   end
 
+  def copied_checklists_details
+    [{
+      'id'         => 'uvwxyz987654321987654321',
+      'name'       => 'Test Checklist',
+      'desc'       => '',
+      'closed'     => nil,
+      'position'   => 99999,
+      'url'        => nil,
+      'idBoard'    => 'abcdef123456789123456789',
+      'idList'     => nil,
+      'idMembers'  => nil,
+      'checkItems' => []
+    }]
+  end
+
+  def copied_checklists_payload
+    JSON.generate(copied_checklists_details)
+  end
+
   def lists_details
     [{
       'id'      => 'abcdef123456789123456789',


### PR DESCRIPTION
I needed a way to create a lot of cards each having a checklist made of the same items.  This pull request makes it possible to take a checklist object and make a copy of it with the same name, board id, and set of items.  The new copy is a different object in Trello and can be given to a card.

The code I used this in looked something like ...

```ruby
list_id = "12345abcde12345"
existing_checklist = Trello::Checklist.find "abcde12345abcde"

new_cards_details = [
  { name: "My First Card", description: "This is information about my first card." },
  { name: "A Second Card", description: "My second card can be described as such." }
]

new_cards_details.each do |card_details|
  new_card = Trello::Card.create card_details.merge(list_id: list_id)
  new_card.add_checklist existing_checklist.copy
end
```

I found this really useful, so I thought I'd submit a PR in case it matched with your ideas for the gem.  Thanks for taking a look.