### PR TITLE
Upgrade rest-client to ~> 1.8.0

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json'
   s.add_dependency 'oauth',       '~> 0.4.5'
-  s.add_dependency 'rest-client', '~> 1.7.2'
+  s.add_dependency 'rest-client', '~> 1.8.0'
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -107,7 +107,7 @@ module Trello
         client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
           and_return label_name_payload
 
-        board.labels.count.should eq(10)
+        board.labels.count.should eq(label_name_details.size)
       end
     end
 


### PR DESCRIPTION
From https://github.com/rubysec/ruby-advisory-db:

Name: rest-client
Version: 1.7.3
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via
Set-Cookie headers in 30x redirection responses
Solution: upgrade to >= 1.8.0

Also fix test suite.