### PR TITLE
Fix spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,9 @@ end
 gemspec
 
 group :development, :spec do
-  gem 'fuubar'
   gem 'jruby-openssl', :platforms => :jruby
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '~> 2.99'
   gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
   gem 'webmock'
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -54,7 +54,7 @@ module Trello
       it "knows if it is closed or open" do
         board.closed?.should_not be_nil
       end
-      
+
       it "knows if it is starred or not" do
         board.starred?.should_not be_nil
       end
@@ -107,7 +107,7 @@ module Trello
         client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
           and_return label_name_payload
 
-        board.labels.count.should eq(10)
+        board.labels.count.should eq(6)
       end
     end
 
@@ -168,7 +168,7 @@ module Trello
     it "is not closed" do
       expect(board.closed?).not_to be(true)
     end
-    
+
      it "is not starred" do
       expect(board.starred?).not_to be(true)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,11 +23,10 @@ require 'stringio'
 
 Trello.logger = Logger.new(StringIO.new)
 
-RSpec::Expectations.configuration.warn_about_potential_false_positives = false
-RSpec.configure do |c|
-  c.filter_run_excluding broken: true
+RSpec.configure do |rspec|
+  rspec.filter_run_excluding broken: true
 
-  c.before :each do
+  rspec.before :each do
     Trello.reset!
   end
 end


### PR DESCRIPTION
* Lock rspec to 2.99 for now to avoid messy deprecation messages
* Remove fuubar, this gem depends on rspec 3
* Fix the board_spec