### PR TITLE
Updates rest-client version

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json'
   s.add_dependency 'oauth',       '~> 0.4.5'
-  s.add_dependency 'rest-client', '~> 1.7.2'
+  s.add_dependency 'rest-client', '~> 1.8.0'
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -107,7 +107,7 @@ module Trello
         client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
           and_return label_name_payload
 
-        board.labels.count.should eq(10)
+        board.labels.count.should eq(label_name_details.length)
       end
     end
 


### PR DESCRIPTION
## What

Version bump on rest-client to 1.8.x fixes a [vulnerability](https://isitvulnerable.com/vulns/557513c4-f150-429c-b7f2-58e21936a535). This PR updates the gemspec to avoid the vulnerability.

Also, a failing test was fixed so the entire suite now passes.

## How to test

I cloned the repo and ran all the rspec tests. They pass.