### PR TITLE
Add move_all_cards to list.rb

### DIFF
--- a/lib/trello/list.rb
+++ b/lib/trello/list.rb
@@ -88,6 +88,13 @@ module Trello
     #    :filter => [ :none, :open, :closed, :all ] # default :open
     many :cards, filter: :open
 
+    def move_all_cards(other_list)
+      client.post("/lists/#{id}/moveAllCards", {
+        idBoard: other_list.board_id,
+        idList: other_list.id
+       })
+    end
+
     # :nodoc:
     def request_prefix
       "/lists/#{id}"

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -110,6 +110,13 @@ module Trello
         client.stub(:get).with('/lists/abcdef123456789123456789/cards', { filter: :open }).and_return cards_payload
         list.cards.count.should be > 0
       end
+
+      it 'moves cards to another list' do
+        other_list = List.new(lists_details.first.merge(id: 'otherListID', cards: []))
+
+        client.stub(:post).with('/lists/abcdef123456789123456789/moveAllCards', { idBoard: other_list.board_id, idList: other_list.id }).and_return cards_payload
+        list.move_all_cards(other_list).should eq cards_payload
+      end
     end
 
     describe '#closed?' do


### PR DESCRIPTION
**What**: Add `move_all_cards` method to lists. 
**Why**: My CI process automatically moves cards from a 'Merged but Undeployed' list to a 'Deployed to Staging - Today's/Date' list, but it currently does it one card at a time. There are potentially 10+ cards in that list, and it's way faster to batch them.
