### PR TITLE
Allow list position to be set and updated

### DIFF
--- a/lib/trello/list.rb
+++ b/lib/trello/list.rb
@@ -30,7 +30,8 @@ module Trello
       def create(options)
         client.create(:list,
             'name'    => options[:name],
-            'idBoard' => options[:board_id])
+            'idBoard' => options[:board_id],
+            'pos'     => options[:pos])
       end
     end
 
@@ -53,14 +54,16 @@ module Trello
       client.post("/lists", {
         name: name,
         closed: closed || false,
-        idBoard: board_id
+        idBoard: board_id,
+        pos: pos
       }).json_into(self)
     end
 
     def update!
       client.put("/lists/#{id}", {
         name: name,
-        closed: closed
+        closed: closed,
+        pos: pos
       })
     end
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -46,12 +46,13 @@ module Trello
       it 'creates a new record and saves it on Trello', refactor: true do
         payload = {
           name: 'Test List',
-          board_id: 'abcdef123456789123456789'
+          board_id: 'abcdef123456789123456789',
+          pos: 42
         }
 
         result = JSON.generate(payload)
 
-        expected_payload = {name: 'Test List', closed: false, idBoard: 'abcdef123456789123456789'}
+        expected_payload = {name: 'Test List', closed: false, idBoard: 'abcdef123456789123456789', pos: 42}
 
         client.should_receive(:post).with('/lists', expected_payload).and_return result
 
@@ -67,11 +68,25 @@ module Trello
 
         payload = {
           name: expected_new_name,
-          closed: false
+          closed: false,
+          pos: list.pos
         }
 
         client.should_receive(:put).once.with('/lists/abcdef123456789123456789', payload)
         list.name = expected_new_name
+        list.save
+      end
+
+      it 'updates position' do
+        new_position = 42
+        payload = {
+          name: list.name,
+          closed: list.closed,
+          pos: new_position
+        }
+
+        client.should_receive(:put).once.with('/lists/abcdef123456789123456789', payload)
+        list.pos = new_position
         list.save
       end
     end
@@ -129,7 +144,8 @@ module Trello
       it 'updates the close attribute to true and saves the list' do
         client.should_receive(:put).once.with('/lists/abcdef123456789123456789', {
           name: list.name,
-          closed: true
+          closed: true,
+          pos: list.pos
         })
 
         list.close!


### PR DESCRIPTION
*What*: adding `pos` to list create/update payload
*Why*: so that I can create a list before or after another list, and avoid reordering my lists every time my CI script creates a new 'Deployed This/Week' list