### PR TITLE
Tests/migrate to expect syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gemspec
 group :development, :spec do
   gem 'jruby-openssl', :platforms => :jruby
   gem 'rake'
-  gem 'rspec', '~> 2.99'
+  gem 'rspec', '~> 3.3.0'
   gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
   gem 'webmock'
 end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -4,33 +4,44 @@ module Trello
   describe Action do
     include Helpers
 
-    let(:action) { client.find(:action, '4ee2482134a81a757a08af47') }
-    let(:client) { Client.new }
+    let(:client)  { Client.new }
+    let(:action)  { client.find(:action, '4ee2482134a81a757a08af47') }
 
-    before(:each) do
-      client.stub(:get).with('/actions/4ee2482134a81a757a08af47', {}).
-        and_return JSON.generate(actions_details.first)
+    before do
+      allow(client)
+        .to receive(:get)
+        .with('/actions/4ee2482134a81a757a08af47', {})
+        .and_return JSON.generate(actions_details.first)
     end
 
     context 'finding' do
       let(:client) { Trello.client }
 
       it 'delegates to Trello.client#find' do
-        client.should_receive(:find).with(:action, '4ee2482134a81a757a08af47', {})
+        expect(client)
+          .to receive(:find)
+          .with(:action, '4ee2482134a81a757a08af47', {})
+
         Action.find('4ee2482134a81a757a08af47')
       end
 
-      it 'is equivalent to client#find' do
-        Action.find('4ee2482134a81a757a08af47').should eq(action)
+      it do
+        expect(Action.find('4ee2482134a81a757a08af47')).to eq(action)
       end
     end
 
     context 'search' do
       let(:client) { Trello.client }
+      let(:payload) { JSON.generate({ "cards" => cards_details }) }
 
-      it "should search and get back a card object" do
-        client.should_receive(:get).with("/search/", { query: "something"}).and_return(JSON.generate({ "cards" => cards_details }))
-        Action.search("something").should eq({ "cards" => cards_details.jsoned_into(Card) })
+      it "searches and get back a card object" do
+        expect(client)
+          .to receive(:get)
+          .with("/search/", { query: "something"})
+          .and_return payload
+
+        expect(Action.search("something"))
+          .to eq({ "cards" => cards_details.jsoned_into(Card) })
       end
     end
 
@@ -38,54 +49,79 @@ module Trello
       let(:detail) { actions_details.first }
 
       it 'gets its id' do
-        action.id.should == detail['id']
+        expect(action.id).to eq detail['id']
       end
 
       it 'gets its type' do
-        action.type.should == detail['type']
+        expect(action.type).to eq detail['type']
       end
 
       it 'has the same data' do
-        action.data.should == detail['data']
+        expect(action.data).to eq detail['data']
       end
 
       it 'gets the date' do
-        action.date.utc.iso8601.should == detail['date']
+        expect(action.date.utc.iso8601).to eq detail['date']
       end
     end
 
     context 'boards' do
-      it 'has a board' do
-        client.stub(:get).with('/actions/4ee2482134a81a757a08af47/board').
-          and_return JSON.generate(boards_details.first)
+      let(:payload) { JSON.generate(boards_details.first) }
 
-        action.board.should_not be_nil
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/actions/4ee2482134a81a757a08af47/board')
+          .and_return payload
+      end
+
+      it 'has a board' do
+        expect(action.board).to_not be_nil
       end
     end
 
-    context 'card' do
-      it 'has a card' do
-        client.stub(:get).with('/actions/4ee2482134a81a757a08af47/card').
-          and_return JSON.generate(cards_details.first)
 
-        action.card.should_not be_nil
+    context 'card' do
+      let(:payload) { JSON.generate(cards_details.first) }
+
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/actions/4ee2482134a81a757a08af47/card')
+          .and_return payload
+      end
+
+      it 'has a card' do
+        expect(action.card).to_not be_nil
       end
     end
 
     context 'list' do
-      it 'has a list of lists' do
-        client.stub(:get).with('/actions/4ee2482134a81a757a08af47/list').
-          and_return JSON.generate(lists_details.first)
+      let(:payload) { JSON.generate(lists_details.first) }
 
-        action.list.should_not be_nil
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/actions/4ee2482134a81a757a08af47/list')
+          .and_return payload
+      end
+
+      it 'has a list of lists' do
+        expect(action.list).to_not be_nil
       end
     end
 
     context 'member creator' do
-      it 'knows its member creator' do
-        client.stub(:get).with('/members/abcdef123456789123456789', {}).and_return user_payload
 
-        action.member_creator.should_not be_nil
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/members/abcdef123456789123456789', {})
+          .and_return user_payload
+      end
+
+      it 'knows its member creator' do
+        expect(action.member_creator).to_not be_nil
       end
     end
   end

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -5,6 +5,6 @@ describe Array, '#jsoned_into' do
   include Helpers
 
   it "should convert an array of parsed json into cards" do
-    cards_details.jsoned_into(Trello::Card).should eq([cards_details.first.jsoned_into(Trello::Card)])
+    expect(cards_details.jsoned_into(Trello::Card)).to eq([cards_details.first.jsoned_into(Trello::Card)])
   end
 end

--- a/spec/association_spec.rb
+++ b/spec/association_spec.rb
@@ -7,16 +7,20 @@ module Trello
     let(:organization) { client.find(:organization, '4ee7e59ae582acdec8000291') }
     let(:client) { Client.new(consumer_key: 'xxx') }
 
-    before(:each) do
-      client.stub(:get).with('/organizations/4ee7e59ae582acdec8000291', {}).
-        and_return organization_payload
-      client.stub(:get).with('/organizations/4ee7e59ae582acdec8000291/boards/all').
-        and_return boards_payload
+    before do
+      allow(client)
+        .to receive(:get)
+        .with('/organizations/4ee7e59ae582acdec8000291', {})
+        .and_return organization_payload
+
+      allow(client)
+        .to receive(:get)
+        .with('/organizations/4ee7e59ae582acdec8000291/boards/all')
+        .and_return boards_payload
     end
 
     it 'should set the proper client for all associated boards of the organization' do
-      organization.boards.first.client.consumer_key.should == 'xxx'
+      expect(organization.boards.first.client.consumer_key).to eq 'xxx'
     end
-
   end
 end

--- a/spec/basic_auth_policy_spec.rb
+++ b/spec/basic_auth_policy_spec.rb
@@ -21,8 +21,8 @@ describe BasicAuthPolicy do
 
     the_query_parameters = Addressable::URI.parse(authorized_request.uri).query_values
 
-    the_query_parameters['key'].should === 'xxx_developer_public_key_xxx'
-    the_query_parameters['token'].should === 'xxx_member_token_xxx'
+    expect(the_query_parameters['key']).to eq 'xxx_developer_public_key_xxx'
+    expect(the_query_parameters['token']).to eq 'xxx_member_token_xxx'
   end
 
   it 'preserves other query parameters' do
@@ -34,7 +34,7 @@ describe BasicAuthPolicy do
 
     the_query_parameters = Addressable::URI.parse(authorized_request.uri).query_values
 
-    the_query_parameters['name'].should == 'Phil'
+    expect(the_query_parameters['name']).to eq 'Phil'
   end
 
   it 'preserves headers' do
@@ -44,7 +44,7 @@ describe BasicAuthPolicy do
 
     authorized_request = BasicAuthPolicy.authorize request
 
-    authorized_request.headers.should === request.headers
+    expect(authorized_request.headers).to eq request.headers
   end
 
   it 'does what when a query parameter already exists called key or token?'

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -93,7 +93,7 @@ module Trello
       before do
         allow(client)
           .to receive(:get)
-          .with("/boards/abcdef123456789123456789/cards", {filter: :open })
+          .with("/boards/abcdef123456789123456789/cards", {filter: :open})
           .and_return cards_payload
       end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -8,21 +8,26 @@ module Trello
     let(:client) { Client.new }
     let(:member) { Member.new(user_payload) }
 
-    before(:each) do
-      client.stub(:get).with("/boards/abcdef123456789123456789", {}).
-        and_return JSON.generate(boards_details.first)
+    before do
+      allow(client)
+        .to receive(:get)
+        .with("/boards/abcdef123456789123456789", {})
+        .and_return JSON.generate(boards_details.first)
     end
 
     context "finding" do
       let(:client) { Trello.client }
 
       it "delegates to client#find" do
-        client.should_receive(:find).with(:board, 'abcdef123456789123456789', {})
+        expect(client)
+          .to receive(:find)
+          .with(:board, 'abcdef123456789123456789', {})
+
         Board.find('abcdef123456789123456789')
       end
 
       it "is equivalent to client#find" do
-        Board.find('abcdef123456789123456789').should eq(board)
+        expect(Board.find('abcdef123456789123456789')).to eq(board)
       end
     end
 
@@ -30,72 +35,94 @@ module Trello
       let(:client) { Trello.client }
 
       it "gets all boards" do
-        Member.stub_chain(:find, :username).and_return "testuser"
-        client.stub(:get).with("/members/testuser/boards").and_return boards_payload
+        allow(Member)
+          .to receive_message_chain(:find, :username)
+          .and_return "testuser"
+
+        allow(client)
+          .to receive(:get)
+          .with("/members/testuser/boards")
+          .and_return boards_payload
 
         expected = Board.new(boards_details.first)
-        Board.all.first.should eq(expected)
+        expect(Board.all.first).to eq(expected)
       end
     end
 
     context "fields" do
       it "gets an id" do
-        board.id.should_not be_nil
+        expect(board.id).to_not be_nil
       end
 
       it "gets a name" do
-        board.name.should_not be_nil
+        expect(board.name).to_not be_nil
       end
 
       it "gets the description" do
-        board.description.should_not be_nil
+        expect(board.description).to_not be_nil
       end
 
       it "knows if it is closed or open" do
-        board.closed?.should_not be_nil
+        expect(board).to_not be_closed
       end
 
       it "knows if it is starred or not" do
-        board.starred?.should_not be_nil
+        expect(board).to_not be_starred
       end
 
       it "gets its url" do
-        board.url.should_not be_nil
+        expect(board.url).to_not be_nil
       end
     end
 
     context "actions" do
-      it "has a list of actions" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/actions", {filter: :all}).
-          and_return actions_payload
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/actions", {filter: :all})
+          .and_return actions_payload
+      end
 
-        board.actions.count.should be > 0
+      it "has a list of actions" do
+        expect(board.actions.count).to be > 0
       end
     end
 
     context "cards" do
-      it "gets its list of cards" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/cards", { filter: :open }).
-          and_return cards_payload
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/cards", {filter: :open })
+          .and_return cards_payload
+      end
 
-        board.cards.count.should be > 0
+      it "gets its list of cards" do
+        expect(board.cards.count).to be > 0
       end
     end
 
     context "labels" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/labels")
+          .and_return label_payload
+
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/labelnames")
+          .and_return label_name_payload
+      end
+
       it "gets the specific labels for the board" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/labels").
-          and_return label_payload
         labels = board.labels false
-        labels.count.should eq(4)
 
-
+        expect(labels.count).to eq(4)
         expect(labels[2].color).to  eq('red')
         expect(labels[2].id).to  eq('abcdef123456789123456789')
         expect(labels[2].board_id).to  eq('abcdef123456789123456789')
         expect(labels[2].name).to  eq('deploy')
         expect(labels[2].uses).to  eq(2)
-
         expect(labels[3].color).to  eq('blue')
         expect(labels[3].id).to  eq('abcdef123456789123456789')
         expect(labels[3].board_id).to  eq('abcdef123456789123456789')
@@ -104,73 +131,106 @@ module Trello
       end
 
       it "gets the specific labels for the board" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/labelnames").
-          and_return label_name_payload
-
-        board.labels.count.should eq(6)
+        expect(board.labels.count).to eq(label_name_details.length)
       end
     end
 
     context "find_card" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/cards/1")
+          .and_return card_payload
+      end
+
       it "gets a card" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/cards/1").
-          and_return card_payload
-        board.find_card(1).should be_a(Card)
+        expect(board.find_card(1)).to be_a(Card)
       end
     end
 
     context "add_member" do
+      before do
+        allow(client)
+          .to receive(:put)
+      end
+
       it "adds a member to the board as a normal user (default)" do
-        client.stub(:put).with("/boards/abcdef123456789123456789/members/id", type: :normal)
+        expect(client)
+          .to receive(:put)
+          .with("/boards/abcdef123456789123456789/members/id", type: :normal)
+
         board.add_member(member)
       end
 
       it "adds a member to the board as an admin" do
-        client.stub(:put).with("/boards/abcdef123456789123456789/members/id", type: :admin)
+        expect(client)
+          .to receive(:put)
+          .with("/boards/abcdef123456789123456789/members/id", type: :admin)
+
         board.add_member(member, :admin)
       end
     end
 
     context "remove_member" do
+      before do
+        allow(client)
+          .to receive(:delete)
+      end
+
       it "removes a member from the board" do
-        client.stub(:delete).with("/boards/abcdef123456789123456789/members/id")
+        expect(client)
+          .to receive(:delete)
+          .with("/boards/abcdef123456789123456789/members/id")
+
         board.remove_member(member)
       end
     end
 
     context "lists" do
-      it "has a list of lists" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/lists", hash_including(filter: :open)).
-          and_return lists_payload
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/lists", hash_including(filter: :open))
+          .and_return lists_payload
+      end
 
-        board.has_lists?.should be true
+      it "has a list of lists" do
+        expect(board).to be_has_lists
       end
     end
 
     context "members" do
-      it "has a list of members" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/members", hash_including(filter: :all)).
-          and_return JSON.generate([user_details])
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/members", hash_including(filter: :all))
+          .and_return JSON.generate([user_details])
+      end
 
-        board.members.count.should be > 0
+      it "has a list of members" do
+        expect(board.members.count).to be > 0
       end
     end
 
     context "organization" do
-      it "belongs to an organization" do
-        client.stub(:get).with("/organizations/abcdef123456789123456789", {}).
-          and_return JSON.generate(orgs_details.first)
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/organizations/abcdef123456789123456789", {})
+          .and_return JSON.generate(orgs_details.first)
+      end
 
-        board.organization.should_not be_nil
+      it "belongs to an organization" do
+        expect(board.organization).to_not be_nil
       end
     end
 
     it "is not closed" do
-      expect(board.closed?).not_to be(true)
+      expect(board).not_to be_closed
     end
 
-     it "is not starred" do
-      expect(board.starred?).not_to be(true)
+    it "is not starred" do
+      expect(board).not_to be_starred
     end
 
     describe "#update_fields" do
@@ -192,12 +252,12 @@ module Trello
 
         expected.each_pair do |key, value|
           if board.respond_to?(key)
-            board.send(key).should == value
+            expect(board.send(key)).to eq value
           end
         end
 
-        board.description.should == expected['desc']
-        board.organization_id.should == expected['idOrganization']
+        expect(board.description).to eq expected['desc']
+        expect(board.organization_id).to eq expected['idOrganization']
       end
 
       it "sets any attributes supplied in the fields argument"
@@ -210,45 +270,47 @@ module Trello
         JSON.generate(boards_details.first)
       end
 
-      it "cannot currently save a new instance" do
-        client.should_not_receive :put
+      before do
+        allow(client)
+          .to receive(:put)
+      end
 
-        the_new_board = Board.new
-        -> { the_new_board.save }.should raise_error
+      it "cannot currently save a new instance" do
+        expect(client).to_not receive(:put)
+        expect {
+          Board.new.save
+        }.to raise_error
       end
 
       it "puts all fields except id" do
         expected_fields = %w{ name description closed starred idOrganization}.map { |s| s.to_sym }
 
-        client.should_receive(:put) do |anything, body|
-          body.keys.should =~ expected_fields
+        expect(client).to receive(:put) do |anything, body|
+          expect(body.keys).to match expected_fields
           any_board_json
         end
 
-        the_new_board = Board.new 'id' => "xxx"
-        the_new_board.save
+        Board.new('id' => "xxx").save
       end
 
       it "mutates the current instance" do
-        client.stub(:put).and_return any_board_json
+        allow(client)
+          .to receive(:put)
+          .and_return any_board_json
 
         board = Board.new 'id' => "xxx"
-
-        the_result_of_save = board.save
-
-        the_result_of_save.should equal board
+        expect(board.save).to eq board
       end
 
       it "uses the correct resource" do
         expected_resource_id = "xxx_board_id_xxx"
 
-        client.should_receive(:put) do |path, anything|
-          path.should =~ /#{expected_resource_id}\/$/
+        expect(client).to receive(:put) do |path, anything|
+          expect(path).to match(/#{expected_resource_id}\/\z/)
           any_board_json
         end
 
-        the_new_board = Board.new 'id' => expected_resource_id
-        the_new_board.save
+        Board.new('id' => expected_resource_id).save
       end
 
       it "saves OR updates depending on whether or not it has an id set"
@@ -267,15 +329,18 @@ module Trello
         board.name        = "new name"
         board.description = "new description"
         board.closed      = true
-        board.starred      = true
+        board.starred     = true
 
-        client.should_receive(:put).with("/boards/#{board.id}/", {
-          name: "new name",
-          description: "new description",
-          closed: true,
-          starred: true,
-          idOrganization: nil
-        }).and_return any_board_json
+        expect(client)
+          .to receive(:put)
+          .with("/boards/#{board.id}/", {
+            name: "new name",
+            description: "new description",
+            closed: true,
+            starred: true,
+            idOrganization: nil })
+          .and_return any_board_json
+
         board.update!
       end
     end
@@ -289,26 +354,39 @@ module Trello
         JSON.generate(boards_details.first)
       end
 
+      before do
+        allow(client)
+          .to receive(:post)
+      end
+
       it "creates a new board with whatever attributes are supplied " do
         expected_attributes = { name: "Any new board name", description: "Any new board desription" }
         sent_attributes = { name: expected_attributes[:name], desc: expected_attributes[:description] }
 
-        client.should_receive(:post).with("/boards", sent_attributes).and_return any_board_json
+        expect(client)
+          .to receive(:post)
+          .with("/boards", sent_attributes)
+          .and_return any_board_json
 
         Board.create expected_attributes
       end
 
       it "posts to the boards collection" do
-        client.should_receive(:post).with("/boards", anything).and_return any_board_json
+        expect(client)
+          .to receive(:post)
+          .with("/boards", anything)
+          .and_return any_board_json
 
         Board.create xxx: ""
       end
 
       it "returns a board" do
-        client.stub(:post).with("/boards", anything).and_return any_board_json
+        allow(client)
+          .to receive(:post)
+          .with("/boards", anything)
+          .and_return any_board_json
 
-        the_new_board = Board.create xxx: ""
-        the_new_board.should be_a Board
+        expect(Board.create(xxx: "")).to be_a Board
       end
 
       it "at least name is required"

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -34,7 +34,7 @@ module Trello
     context "self.all" do
       let(:client) { Trello.client }
 
-      it "gets all boards" do
+      before do
         allow(Member)
           .to receive_message_chain(:find, :username)
           .and_return "testuser"
@@ -43,9 +43,10 @@ module Trello
           .to receive(:get)
           .with("/members/testuser/boards")
           .and_return boards_payload
+      end
 
-        expected = Board.new(boards_details.first)
-        expect(Board.all.first).to eq(expected)
+      it "gets all boards" do
+        expect(Board.all.first).to eq Board.new(boards_details.first)
       end
     end
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -4,24 +4,34 @@ module Trello
   describe Card do
     include Helpers
 
-    let(:card) { client.find(:card, 'abcdef123456789123456789') }
+    let(:card)   { client.find(:card, 'abcdef123456789123456789') }
     let(:client) { Client.new }
 
-    before(:each) do
-      client.stub(:get).with("/cards/abcdef123456789123456789", {}).
-        and_return JSON.generate(cards_details.first)
+    before do
+      allow(client)
+        .to receive(:get)
+        .with("/cards/abcdef123456789123456789", {})
+        .and_return JSON.generate(cards_details.first)
     end
 
     context "finding" do
       let(:client) { Trello.client }
 
+      before do
+        allow(client)
+          .to receive(:find)
+      end
+
       it "delegates to Trello.client#find" do
-        client.should_receive(:find).with(:card, 'abcdef123456789123456789', {})
+        expect(client)
+          .to receive(:find)
+          .with(:card, 'abcdef123456789123456789', {})
+
         Card.find('abcdef123456789123456789')
       end
 
       it "is equivalent to client#find" do
-        Card.find('abcdef123456789123456789').should eq(card)
+        expect(Card.find('abcdef123456789123456789')).to eq(card)
       end
     end
 
@@ -30,17 +40,17 @@ module Trello
 
       it "creates a new record" do
         card = Card.new(cards_details.first)
-        card.should be_valid
+        expect(card).to be_valid
       end
 
       it 'must not be valid if not given a name' do
         card = Card.new('idList' => lists_details.first['id'])
-        card.should_not be_valid
+        expect(card).to_not be_valid
       end
 
       it 'must not be valid if not given a list id' do
         card = Card.new('name' => lists_details.first['name'])
-        card.should_not be_valid
+        expect(card).to_not be_valid
       end
 
       it 'creates a new record and saves it on Trello', refactor: true do
@@ -54,11 +64,14 @@ module Trello
         expected_payload = {name: "Test Card", desc: nil, idList: "abcdef123456789123456789",
                             idMembers: nil, labels: nil, pos: nil, due: nil}
 
-        client.should_receive(:post).with("/cards", expected_payload).and_return result
+        expect(client)
+          .to receive(:post)
+          .with("/cards", expected_payload)
+          .and_return result
 
         card = Card.create(cards_details.first.merge(payload.merge(list_id: lists_details.first['id'])))
 
-        card.class.should be Card
+        expect(card).to be_a Card
       end
     end
 
@@ -70,7 +83,10 @@ module Trello
           name: expected_new_name,
         }
 
-        client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with("/cards/abcdef123456789123456789", payload)
 
         card.name = expected_new_name
         card.save
@@ -79,124 +95,172 @@ module Trello
 
     context "deleting" do
       it "deletes the card" do
-        client.should_receive(:delete).with("/cards/#{card.id}")
+        expect(client)
+          .to receive(:delete)
+          .with("/cards/#{card.id}")
+
         card.delete
       end
     end
 
     context "fields" do
       it "gets its id" do
-        card.id.should_not be_nil
+        expect(card.id).to_not be_nil
       end
 
       it "gets its short id" do
-        card.short_id.should_not be_nil
+        expect(card.short_id).to_not be_nil
       end
 
       it "gets its name" do
-        card.name.should_not be_nil
+        expect(card.name).to_not be_nil
       end
 
       it "gets its description" do
-        card.desc.should_not be_nil
+        expect(card.desc).to_not be_nil
       end
 
       it "knows if it is open or closed" do
-        card.closed.should_not be_nil
+        expect(card.closed).to_not be_nil
       end
 
       it "gets its url" do
-        card.url.should_not be_nil
+        expect(card.url).to_not be_nil
       end
 
       it "gets its short url" do
-        card.short_url.should_not be_nil
+        expect(card.short_url).to_not be_nil
       end
 
       it "gets its last active date" do
-        card.last_activity_date.should_not be_nil
+        expect(card.last_activity_date).to_not be_nil
       end
 
       it "gets its cover image id" do
-        card.cover_image_id.should_not be_nil
+        expect(card.cover_image_id).to_not be_nil
       end
 
       it "gets its pos" do
-        card.pos.should_not be_nil
+        expect(card.pos).to_not be_nil
       end
     end
 
     context "actions" do
-      it "asks for all actions by default" do
-        client.stub(:get).with("/cards/abcdef123456789123456789/actions", { filter: :all }).and_return actions_payload
-        card.actions.count.should be > 0
+      let(:filter) { :all }
+
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/actions", { filter: filter })
+          .and_return actions_payload
       end
 
-      it "allows overriding the filter" do
-        client.stub(:get).with("/cards/abcdef123456789123456789/actions", { filter: :updateCard }).and_return actions_payload
-        card.actions(filter: :updateCard).count.should be > 0
+      it "asks for all actions by default" do
+        expect(card.actions.count).to be > 0
+      end
+
+      context 'when overriding a filter' do
+        let(:filter) { :updateCard }
+
+        it "allows the filter" do
+          expect(card.actions(filter: filter).count).to be > 0
+        end
       end
     end
 
     context "boards" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789", {})
+          .and_return JSON.generate(boards_details.first)
+      end
+
       it "has a board" do
-        client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
-        card.board.should_not be_nil
+        expect(card.board).to_not be_nil
       end
     end
 
     context "cover image" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/attachments/abcdef123456789123456789", {})
+          .and_return JSON.generate(attachments_details.first)
+      end
+
       it "has a cover image" do
-        client.stub(:get).with("/attachments/abcdef123456789123456789", {}).and_return JSON.generate(attachments_details.first)
-        card.cover_image.should_not be_nil
+        expect(card.cover_image).to_not be_nil
       end
     end
 
     context "checklists" do
-      before(:each) do
-        client.stub(:get).with("/cards/abcdef123456789123456789/checklists", { filter: :all }).and_return checklists_payload
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/checklists", { filter: :all})
+          .and_return checklists_payload
       end
 
       it "has a list of checklists" do
-        card.checklists.count.should be > 0
+        expect(card.checklists.count).to be > 0
       end
 
       it "creates a new checklist for the card" do
-        client.should_receive(:post).with("/cards/abcdef123456789123456789/checklists", name: "new checklist")
+        expect(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/checklists", name: "new checklist")
+
         card.create_new_checklist("new checklist")
       end
     end
 
     context "list" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/lists/abcdef123456789123456789", {})
+          .and_return JSON.generate(lists_details.first)
+      end
       it 'has a list' do
-        client.stub(:get).with("/lists/abcdef123456789123456789", {}).and_return JSON.generate(lists_details.first)
-        card.list.should_not be_nil
+        expect(card.list).to_not be_nil
       end
 
       it 'can be moved to another list' do
         other_list = double(id: '987654321987654321fedcba')
         payload = {value: other_list.id}
-        client.should_receive(:put).with("/cards/abcdef123456789123456789/idList", payload)
+
+        expect(client)
+          .to receive(:put)
+          .with("/cards/abcdef123456789123456789/idList", payload)
+
         card.move_to_list(other_list)
       end
 
       it 'should not be moved if new list is identical to old list' do
         other_list = double(id: 'abcdef123456789123456789')
-        payload = { value: other_list.id }
-        client.should_not_receive(:put)
+        expect(client).to_not receive(:put)
         card.move_to_list(other_list)
       end
 
       it "should accept a string for moving a card to list" do
         payload = { value: "12345678"}
-        client.should_receive(:put).with("/cards/abcdef123456789123456789/idList", payload)
+
+        expect(client)
+          .to receive(:put)
+          .with("/cards/abcdef123456789123456789/idList", payload)
+
         card.move_to_list("12345678")
       end
 
       it 'can be moved to another board' do
         other_board = double(id: '987654321987654321fedcba')
         payload = {value: other_board.id}
-        client.should_receive(:put).with("/cards/abcdef123456789123456789/idBoard", payload)
+
+        expect(client)
+          .to receive(:put)
+          .with("/cards/abcdef123456789123456789/idBoard", payload)
+
         card.move_to_board(other_board)
       end
 
@@ -204,24 +268,37 @@ module Trello
         other_board = double(id: '987654321987654321fedcba')
         other_list = double(id: '987654321987654321aalist')
         payload = {value: other_board.id, idList: other_list.id}
-        client.should_receive(:put).with("/cards/abcdef123456789123456789/idBoard", payload)
+
+        expect(client)
+          .to receive(:put)
+          .with("/cards/abcdef123456789123456789/idBoard", payload)
+
         card.move_to_board(other_board, other_list)
       end
 
       it 'should not be moved if new board is identical with old board', focus: true do
         other_board = double(id: 'abcdef123456789123456789')
-        client.should_not_receive(:put)
+        expect(client).to_not receive(:put)
         card.move_to_board(other_board)
       end
     end
 
     context "members" do
-      it "has a list of members" do
-        client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
-        client.stub(:get).with("/members/abcdef123456789123456789").and_return user_payload
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789", {})
+          .and_return JSON.generate(boards_details.first)
 
-        card.board.should_not be_nil
-        card.members.should_not be_nil
+        allow(client)
+          .to receive(:get)
+          .with("/members/abcdef123456789123456789")
+          .and_return user_payload
+      end
+
+      it "has a list of members" do
+        expect(card.board).to_not be_nil
+        expect(card.members).to_not be_nil
       end
 
       it "allows a member to be added to a card" do
@@ -229,40 +306,61 @@ module Trello
         payload = {
           value: new_member.id
         }
-        client.should_receive(:post).with("/cards/abcdef123456789123456789/members", payload)
+
+        expect(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/members", payload)
+
         card.add_member(new_member)
       end
 
       it "allows a member to be removed from a card" do
         existing_member = double(id: '4ee7df3ce582acdec80000b2')
-        client.should_receive(:delete).with("/cards/abcdef123456789123456789/members/#{existing_member.id}")
+
+        expect(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/members/#{existing_member.id}")
+
         card.remove_member(existing_member)
       end
     end
 
     context "comments" do
       it "posts a comment" do
-        client.should_receive(:post).
-          with("/cards/abcdef123456789123456789/actions/comments", { text: 'testing' }).
-          and_return JSON.generate(boards_details.first)
+        expect(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/actions/comments", { text: 'testing' })
+          .and_return JSON.generate(boards_details.first)
 
         card.add_comment "testing"
       end
     end
 
     context "labels" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/labels")
+          .and_return label_payload
+
+        allow(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/labels", { value: 'green' })
+          .and_return "not important"
+
+        allow(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/labels/green")
+          .and_return "not important"
+      end
       it "can retrieve labels" do
-        client.stub(:get).with("/cards/abcdef123456789123456789/labels").
-          and_return label_payload
         labels = card.labels
         expect(labels.size).to  eq(4)
-
         expect(labels[0].color).to  eq('yellow')
         expect(labels[0].id).to  eq('abcdef123456789123456789')
         expect(labels[0].board_id).to  eq('abcdef123456789123456789')
         expect(labels[0].name).to  eq('iOS')
         expect(labels[0].uses).to  eq(3)
-
         expect(labels[1].color).to  eq('purple')
         expect(labels[1].id).to  eq('abcdef123456789123456789')
         expect(labels[1].board_id).to  eq('abcdef123456789123456789')
@@ -271,50 +369,63 @@ module Trello
       end
 
       it "can add a label" do
-        client.stub(:post).with("/cards/abcdef123456789123456789/labels", { value: 'green' }).
-          and_return "not important"
         card.add_label('green')
         expect(card.errors).to be_empty
       end
 
       it "can remove a label" do
-        client.stub(:delete).with("/cards/abcdef123456789123456789/labels/green").
-          and_return "not important"
         card.remove_label('green')
         expect(card.errors).to be_empty
       end
 
       it "can remove a label instance" do
-        client.should_receive(:delete).once.with("/cards/abcdef123456789123456789/idLabels/abcdef123456789123456789")
+        expect(client)
+          .to receive(:delete)
+          .once
+          .with("/cards/abcdef123456789123456789/idLabels/abcdef123456789123456789")
+
         label = Label.new(label_details.first)
         card.remove_label(label)
       end
 
-      it "can add a label of any valid color" do
-        %w(green yellow orange red purple blue sky lime pink black).each do |color|
-          client.stub(:post).with("/cards/abcdef123456789123456789/labels", { :value => color }).
-            and_return "not important"
+      %w(green yellow orange red purple blue sky lime pink black).each do |color|
+        it "can add a label of color: #{color}" do
+          allow(client)
+            .to receive(:post)
+            .with("/cards/abcdef123456789123456789/labels", { :value => color })
+            .and_return "not important"
+
           card.add_label(color)
           expect(card.errors).to be_empty
         end
       end
 
       it "can add a label instance" do
-        client.should_receive(:post).once.with("/cards/abcdef123456789123456789/idLabels", {:value => "abcdef123456789123456789"})
-        label = Label.new(label_details.first)
-        card.add_label label
+        expect(client)
+          .to receive(:post)
+          .once
+          .with("/cards/abcdef123456789123456789/idLabels", {:value => "abcdef123456789123456789"})
+
+        card.add_label Label.new(label_details.first)
       end
 
       it "throws an error when trying to add a label with an unknown colour" do
-        client.stub(:post).with("/cards/abcdef123456789123456789/labels", { value: 'green' }).
-          and_return "not important"
+        allow(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/labels", { value: 'green' })
+          .and_return "not important"
+
         card.add_label('mauve')
+
         expect(card.errors.full_messages.to_sentence).to eq("Label colour 'mauve' does not exist")
       end
 
       it "throws an error when trying to remove a label with an unknown colour" do
-        client.stub(:delete).with("/cards/abcdef123456789123456789/labels/mauve").
-          and_return "not important"
+        allow(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/labels/mauve")
+          .and_return "not important"
+
         card.remove_label('mauve')
         expect(card.errors.full_messages.to_sentence).to eq("Label colour 'mauve' does not exist")
       end
@@ -323,67 +434,86 @@ module Trello
     context "attachments" do
       it "can add an attachment" do
         f = File.new('spec/list_spec.rb', 'r')
-        client.stub(:get).with("/cards/abcdef123456789123456789/attachments").and_return attachments_payload
-        client.stub(:post).with("/cards/abcdef123456789123456789/attachments",
-              { file: f, name: ''  }).
-              and_return "not important"
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/attachments")
+          .and_return attachments_payload
+
+        allow(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/attachments", { file: f, name: ''  })
+          .and_return "not important"
 
         card.add_attachment(f)
 
-        card.errors.should be_empty
+        expect(card.errors).to be_empty
       end
 
       it "can list the existing attachments with correct fields" do
-        client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
-        client.stub(:get).with("/cards/abcdef123456789123456789/attachments").and_return attachments_payload
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789", {})
+          .and_return JSON.generate(boards_details.first)
 
-        card.board.should_not be_nil
-        card.attachments.should_not be_nil
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/attachments")
+          .and_return attachments_payload
+
+        expect(card.board).to_not be_nil
+        expect(card.attachments).to_not be_nil
+
         first_attachment = card.attachments.first
-        first_attachment.id.should == attachments_details[0]["id"]
-        first_attachment.name.should == attachments_details[0]["name"]
-        first_attachment.url.should == attachments_details[0]["url"]
-        first_attachment.bytes.should == attachments_details[0]["bytes"]
-        first_attachment.member_id.should == attachments_details[0]["idMember"]
-        first_attachment.date.should == Time.parse(attachments_details[0]["date"])
-        first_attachment.is_upload.should == attachments_details[0]["isUpload"]
-        first_attachment.mime_type.should == attachments_details[0]["mimeType"]
+        expect(first_attachment.id).to eq attachments_details[0]["id"]
+        expect(first_attachment.name).to eq attachments_details[0]["name"]
+        expect(first_attachment.url).to eq attachments_details[0]["url"]
+        expect(first_attachment.bytes).to eq attachments_details[0]["bytes"]
+        expect(first_attachment.member_id).to eq attachments_details[0]["idMember"]
+        expect(first_attachment.date).to eq Time.parse(attachments_details[0]["date"])
+        expect(first_attachment.is_upload).to eq attachments_details[0]["isUpload"]
+        expect(first_attachment.mime_type).to eq attachments_details[0]["mimeType"]
       end
 
       it "can remove an attachment" do
-        client.stub(:delete).with("/cards/abcdef123456789123456789/attachments/abcdef123456789123456789").
-          and_return "not important"
-        client.stub(:get).with("/cards/abcdef123456789123456789/attachments").and_return attachments_payload
+        allow(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/attachments/abcdef123456789123456789")
+          .and_return "not important"
+
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/attachments")
+          .and_return attachments_payload
 
         card.remove_attachment(card.attachments.first)
-        card.errors.should be_empty
+        expect(card.errors).to be_empty
       end
     end
 
     describe "#closed?" do
       it "returns the closed attribute" do
-        expect(card.closed?).to be(false)
+        expect(card).to_not be_closed
       end
     end
 
     describe "#close" do
       it "updates the close attribute to true" do
         card.close
-        expect(card.closed).to be(true)
+        expect(card).to be_closed
       end
     end
 
     describe "#close!" do
       it "updates the close attribute to true and saves the list" do
-        payload = {
-          closed: true,
-        }
+        payload = { closed: true }
 
-        client.should_receive(:put).once.with("/cards/abcdef123456789123456789", payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with("/cards/abcdef123456789123456789", payload)
 
         card.close!
       end
     end
-
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -15,14 +15,20 @@ describe Client, "and how it handles authorization" do
   before do
     TInternet.stub(:execute).and_return fake_ok_response
     Authorization::AuthPolicy.stub(:new).and_return(auth_policy)
-    auth_policy.stub(:authorize) do |request|
-      request
-    end
+    allow(auth_policy)
+      .to receive(:authorize) { |request| request }
   end
 
   it "authorizes before it queries the internet" do
-    auth_policy.should_receive(:authorize).once.ordered
-    TInternet.should_receive(:execute).once.ordered
+    expect(auth_policy)
+      .to receive(:authorize)
+      .once
+      .ordered
+
+    expect(TInternet)
+      .to receive(:execute)
+      .once
+      .ordered
 
     client.get "/xxx"
   end
@@ -31,7 +37,10 @@ describe Client, "and how it handles authorization" do
     expected_uri = Addressable::URI.parse("https://api.trello.com/1/xxx?a=1&b=2")
     expected_request = Request.new :get, expected_uri, {}
 
-    TInternet.should_receive(:execute).once.with expected_request
+    expect(TInternet)
+      .to receive(:execute)
+      .once
+      .with expected_request
 
     client.get "/xxx", a: "1", b: "2"
   end
@@ -40,7 +49,10 @@ describe Client, "and how it handles authorization" do
     expected_uri = Addressable::URI.parse("https://api.trello.com/1/xxx?name=Jazz%20Kang")
     expected_request = Request.new :get, expected_uri, {}
 
-    TInternet.should_receive(:execute).once.with expected_request
+    expect(TInternet)
+      .to receive(:execute)
+      .once
+      .with expected_request
 
     client.get "/xxx", name: "Jazz Kang"
   end
@@ -51,31 +63,40 @@ describe Client, "and how it handles authorization" do
       code: 404,
       body: expected_error_message
 
-    TInternet.stub(:execute).and_return response_with_non_200_status
+    expect(TInternet)
+      .to receive(:execute)
+      .and_return response_with_non_200_status
 
-    -> { client.get "/xxx" }.should raise_error expected_error_message
+    expect { client.get "/xxx" }.to raise_error expected_error_message
   end
 
   it "uses version 1 of the API" do
-    TInternet.should_receive(:execute).once do |request|
-      request.uri.to_s.should =~ /1\//
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.uri.to_s).to match(/1\//)
+        fake_ok_response
+      end
 
     client.get "/"
   end
 
   it "omits the \"?\" when no parameters" do
-    TInternet.should_receive(:execute).once do |request|
-      request.uri.to_s.should_not =~ /\?$/
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.uri.to_s).not_to match(/\?$/)
+        fake_ok_response
+      end
 
     client.get "/xxx"
   end
 
   it "supports post" do
-    TInternet.should_receive(:execute).once.and_return fake_ok_response
+    expect(TInternet)
+      .to receive(:execute)
+      .once
+      .and_return fake_ok_response
 
     client.post "/xxx", { phil: "T' north" }
   end
@@ -83,10 +104,12 @@ describe Client, "and how it handles authorization" do
   it "supplies the body for a post" do
     expected_body = { name: "Phil", nickname: "The Crack Fox" }
 
-    TInternet.should_receive(:execute).once do |request|
-      request.body.should == expected_body
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.body).to eq expected_body
+        fake_ok_response
+      end
 
     client.post "/xxx", expected_body
   end
@@ -94,16 +117,21 @@ describe Client, "and how it handles authorization" do
   it "supplies the path for a post" do
     expected_path = "/xxx"
 
-    TInternet.should_receive(:execute).once do |request|
-      request.uri.path.should =~ /#{expected_path}$/
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.uri.path).to match(/#{expected_path}$/)
+        fake_ok_response
+      end
 
     client.post "/xxx", {}
   end
 
   it "supports put" do
-    TInternet.should_receive(:execute).once.and_return fake_ok_response
+    expect(TInternet)
+      .to receive(:execute)
+      .once
+      .and_return fake_ok_response
 
     client.put "/xxx", { phil: "T' north" }
   end
@@ -111,10 +139,12 @@ describe Client, "and how it handles authorization" do
   it "supplies the body for a put" do
     expected_body = { name: "Phil", nickname: "The Crack Fox" }
 
-    TInternet.should_receive(:execute).once do |request|
-      request.body.should == expected_body
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.body).to eq expected_body
+        fake_ok_response
+      end
 
     client.put "/xxx", expected_body
   end
@@ -122,10 +152,12 @@ describe Client, "and how it handles authorization" do
   it "supplies the path for a put" do
     expected_path = "/xxx"
 
-    TInternet.should_receive(:execute).once do |request|
-      request.uri.path.should =~ /#{expected_path}$/
-      fake_ok_response
-    end
+    expect(TInternet)
+      .to receive(:execute)
+      .once do |request|
+        expect(request.uri.path).to match(/#{expected_path}$/)
+        fake_ok_response
+      end
 
     client.put "/xxx", {}
   end
@@ -141,10 +173,10 @@ describe Client, "and how it handles authorization" do
     end
 
     it "is configurable" do
-      client.consumer_key.should eq('consumer_key')
-      client.consumer_secret.should eq('consumer_secret')
-      client.oauth_token.should eq('oauth_token')
-      client.oauth_token_secret.should eq('oauth_token_secret')
+      expect(client.consumer_key).to eq('consumer_key')
+      expect(client.consumer_secret).to eq('consumer_secret')
+      expect(client.oauth_token).to eq('oauth_token')
+      expect(client.oauth_token_secret).to eq('oauth_token_secret')
     end
   end
 
@@ -157,10 +189,10 @@ describe Client, "and how it handles authorization" do
         config.oauth_token_secret = 'oauth_token_secret'
       end
 
-      client.consumer_key.should eq('consumer_key')
-      client.consumer_secret.should eq('consumer_secret')
-      client.oauth_token.should eq('oauth_token')
-      client.oauth_token_secret.should eq('oauth_token_secret')
+      expect(client.consumer_key).to eq('consumer_key')
+      expect(client.consumer_secret).to eq('consumer_secret')
+      expect(client.oauth_token).to eq('oauth_token')
+      expect(client.oauth_token_secret).to eq('oauth_token_secret')
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,8 +13,14 @@ describe Client, "and how it handles authorization" do
   let(:auth_policy) { double }
 
   before do
-    TInternet.stub(:execute).and_return fake_ok_response
-    Authorization::AuthPolicy.stub(:new).and_return(auth_policy)
+    allow(TInternet)
+      .to receive(:execute)
+      .and_return fake_ok_response
+
+    allow(Authorization::AuthPolicy)
+      .to receive(:new)
+      .and_return(auth_policy)
+
     allow(auth_policy)
       .to receive(:authorize) { |request| request }
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,45 +3,26 @@ require 'spec_helper'
 describe Trello::Configuration do
   let(:configuration) { Trello::Configuration.new }
 
-  it 'has a consumer_key attribute' do
-    configuration.consumer_key = 'consumer_key'
-    configuration.consumer_key.should eq('consumer_key')
-  end
+  [
+    :consumer_key,
+    :consumer_secret,
+    :oauth_token,
+    :oauth_token_secret,
+    :developer_public_key,
+    :member_token,
+    :return_url
 
-  it 'has a consumer_secret attribute' do
-    configuration.consumer_secret = 'consumer_secret'
-    configuration.consumer_secret.should eq('consumer_secret')
-  end
-
-  it 'has a oauth_token attribute' do
-    configuration.oauth_token = 'oauth_token'
-    configuration.oauth_token.should eq('oauth_token')
-  end
-
-  it 'has a oauth_token_secret attribute' do
-    configuration.oauth_token_secret = 'oauth_token_secret'
-    configuration.oauth_token_secret.should eq('oauth_token_secret')
-  end
-
-  it 'has a developer public key attribute' do
-    configuration.developer_public_key = 'developer_public_key'
-    configuration.developer_public_key.should eq('developer_public_key')
-  end
-
-  it 'has a member token attribute' do
-    configuration.member_token = 'member_token'
-    configuration.member_token.should eq('member_token')
+  ].each do |attribute|
+    it "has a #{attribute} attribute" do
+      configuration.public_send(:"#{attribute}=", attribute)
+      expect(configuration.public_send(attribute)).to eq attribute
+    end
   end
 
   it 'has a callback (for oauth)' do
     callback = -> { 'foobar' }
     configuration.callback = callback
-    configuration.callback.call.should eq('foobar')
-  end
-
-  it 'has a return_url' do
-    configuration.return_url = 'http://www.example.com/callback'
-    configuration.return_url.should eq('http://www.example.com/callback')
+    expect(configuration.callback.call).to eq('foobar')
   end
 
   describe 'initialize' do
@@ -52,10 +33,10 @@ describe Trello::Configuration do
         oauth_token: 'oauth_token',
         oauth_token_secret: 'oauth_token_secret'
       )
-      configuration.consumer_key.should eq('consumer_key')
-      configuration.consumer_secret.should eq('consumer_secret')
-      configuration.oauth_token.should eq('oauth_token')
-      configuration.oauth_token_secret.should eq('oauth_token_secret')
+      expect(configuration.consumer_key).to eq('consumer_key')
+      expect(configuration.consumer_secret).to eq('consumer_secret')
+      expect(configuration.oauth_token).to eq('oauth_token')
+      expect(configuration.oauth_token_secret).to eq('oauth_token_secret')
     end
   end
 
@@ -63,11 +44,11 @@ describe Trello::Configuration do
     let(:configuration) { Trello::Configuration.new(attributes) }
 
     it 'returns an empty if no attributes specified' do
-      Trello::Configuration.new({}).credentials.should eq({})
+      expect(Trello::Configuration.new({}).credentials).to eq({})
     end
 
     it 'returns an empty if attributes incomplete' do
-      Trello::Configuration.new(consumer_key: 'consumer_key').credentials.should eq({})
+      expect(Trello::Configuration.new(consumer_key: 'consumer_key').credentials).to eq({})
     end
 
     it 'returns a hash of oauth attributes' do
@@ -77,7 +58,7 @@ describe Trello::Configuration do
         oauth_token: 'oauth_token',
         oauth_token_secret: 'oauth_token_secret'
       )
-      configuration.credentials.should eq(
+      expect(configuration.credentials).to eq(
         consumer_key: 'consumer_key',
         consumer_secret: 'consumer_secret',
         oauth_token: 'oauth_token',
@@ -92,7 +73,7 @@ describe Trello::Configuration do
         return_url: 'http://example.com',
         callback: 'callback'
       )
-      configuration.credentials.should eq(
+      expect(configuration.credentials).to eq(
         consumer_key: 'consumer_key',
         consumer_secret: 'consumer_secret',
         return_url: 'http://example.com',
@@ -105,7 +86,7 @@ describe Trello::Configuration do
         developer_public_key: 'developer_public_key',
         member_token: 'member_token'
       )
-      configuration.credentials.should eq(
+      expect(configuration.credentials).to eq(
         developer_public_key: 'developer_public_key',
         member_token: 'member_token'
       )

--- a/spec/hash_spec.rb
+++ b/spec/hash_spec.rb
@@ -5,7 +5,11 @@ describe Hash, '#jsoned_into' do
   include Helpers
 
   it "should convert a single parsed json into card" do
-    Trello::Card.should_receive(:new).once.with(cards_details.first)
+    expect(Trello::Card)
+      .to receive(:new)
+      .once
+      .with(cards_details.first)
+
     cards_details.first.jsoned_into(Trello::Card)
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -2,36 +2,36 @@ require 'spec_helper'
 
 module Trello
   describe Item do
-    before(:all) do
-      @detail = {
+    let(:details) {
+      {
         'id'   => 'abcdef123456789123456789',
         'name' => 'test item',
         'type' => 'check',
         'state' => 'complete',
         'pos' => 0
       }
+    }
 
-      @item = Item.new(@detail)
-    end
+    let(:item) { Item.new(details) }
 
     it 'gets its id' do
-      @item.id.should == @detail['id']
+      expect(item.id).to eq details['id']
     end
 
     it 'gets its name' do
-      @item.name.should == @detail['name']
+      expect(item.name).to eq details['name']
     end
 
     it 'knows its type' do
-      @item.type.should == @detail['type']
+      expect(item.type).to eq details['type']
     end
 
     it 'knows its state' do
-      @item.state.should == @detail['state']
+      expect(item.state).to eq details['state']
     end
 
     it 'knows its pos' do
-      @item.pos.should == @detail['pos']
+      expect(item.pos).to eq details['pos']
     end
 
     describe '#complete?' do

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -35,14 +35,20 @@ module Trello
     end
 
     describe '#complete?' do
-      it "knows when it is complete" do
-        allow(@item).to receive(:state).and_return "complete"
-        expect(@item).to be_complete
+      before do
+        allow(item)
+          .to receive(:state)
+          .and_return state
       end
 
-      it "knowns when it is not complete" do
-        allow(@item).to receive(:state).and_return "incomplete"
-        expect(@item).to_not be_complete
+      context 'when complete' do
+        let(:state) { 'complete' }
+        it { expect(item).to be_complete }
+      end
+
+      context 'when complete' do
+        let(:state) { 'incomplete' }
+        it { expect(item).not_to be_complete }
       end
     end
   end

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -7,21 +7,26 @@ module Trello
     let(:label) { client.find(:label, 'abcdef123456789123456789') }
     let(:client) { Client.new }
 
-    before(:each) do
-      client.stub(:get).with("/labels/abcdef123456789123456789", {}).
-      and_return JSON.generate(label_details.first)
+    before do
+      allow(client)
+        .to receive(:get)
+        .with("/labels/abcdef123456789123456789", {})
+        .and_return JSON.generate(label_details.first)
     end
 
     context "finding" do
       let(:client) { Trello.client }
 
       it "delegates to Trello.client#find" do
-        client.should_receive(:find).with(:label, 'abcdef123456789123456789', {})
+        expect(client)
+          .to receive(:find)
+          .with(:label, 'abcdef123456789123456789', {})
+
         Label.find('abcdef123456789123456789')
       end
 
       it "is equivalent to client#find" do
-        Label.find('abcdef123456789123456789').should eq(label)
+        expect(Label.find('abcdef123456789123456789')).to eq(label)
       end
     end
 
@@ -29,18 +34,15 @@ module Trello
       let(:client) { Trello.client }
 
       it "creates a new record" do
-        label = Label.new(label_details.first)
-        label.should be_valid
+        expect(Label.new(label_details.first)).to be_valid
       end
 
       it 'must not be valid if not given a name' do
-        label = Label.new('idBoard' => lists_details.first['board_id'])
-        label.should_not be_valid
+        expect(Label.new('idBoard' => lists_details.first['board_id'])).to_not be_valid
       end
 
       it 'must not be valid if not given a board id' do
-        label = Label.new('name' => lists_details.first['name'])
-        label.should_not be_valid
+        expect(Label.new('name' => lists_details.first['name'])).to_not be_valid
       end
 
       it 'creates a new record and saves it on Trello', refactor: true do
@@ -53,11 +55,14 @@ module Trello
 
         expected_payload = {name: "Test Label", color: nil, idBoard: "abcdef123456789123456789" }
 
-        client.should_receive(:post).with("/labels", expected_payload).and_return result
+        expect(client)
+          .to receive(:post)
+          .with("/labels", expected_payload)
+          .and_return result
 
         label = Label.create(label_details.first.merge(payload.merge(board_id: boards_details.first['id'])))
 
-        label.class.should be Label
+        expect(label).to be_a Label
       end
     end
 
@@ -69,7 +74,10 @@ module Trello
           name: expected_new_name,
         }
 
-        client.should_receive(:put).once.with("/labels/abcdef123456789123456789", payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with("/labels/abcdef123456789123456789", payload)
 
         label.name = expected_new_name
         label.save
@@ -82,7 +90,10 @@ module Trello
           color: expected_new_color,
         }
 
-        client.should_receive(:put).once.with("/labels/abcdef123456789123456789", payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with("/labels/abcdef123456789123456789", payload)
 
         label.color = expected_new_color
         label.save
@@ -90,8 +101,11 @@ module Trello
 
       it "can update with any valid color" do
         %w(green yellow orange red purple blue sky lime pink black).each do |color|
-          client.stub(:put).with("/labels/abcdef123456789123456789", {color: color}).
-            and_return "not important"
+          allow(client)
+            .to receive(:put)
+            .with("/labels/abcdef123456789123456789", {color: color})
+            .and_return "not important"
+
           label.color = color
           label.save
           expect(label.errors).to be_empty
@@ -99,43 +113,54 @@ module Trello
       end
 
       it "throws an error when trying to update a label with an unknown colour" do
-        client.stub(:put).with("/labels/abcdef123456789123456789", {}).
-          and_return "not important"
+        allow(client)
+          .to receive(:put)
+          .with("/labels/abcdef123456789123456789", {})
+          .and_return "not important"
+
         label.color = 'mauve'
         label.save
+
         expect(label.errors.full_messages.to_sentence).to eq("Label color 'mauve' does not exist")
       end
     end
 
     context "deleting" do
       it "deletes the label" do
-        client.should_receive(:delete).with("/labels/#{label.id}")
+        expect(client)
+          .to receive(:delete)
+          .with("/labels/#{label.id}")
+
         label.delete
       end
     end
 
     context "fields" do
       it "gets its id" do
-        label.id.should_not be_nil
+        expect(label.id).to_not be_nil
       end
 
       it "gets its name" do
-        label.name.should_not be_nil
+        expect(label.name).to_not be_nil
       end
 
       it "gets its usage" do
-        label.uses.should_not be_nil
+        expect(label.uses).to_not be_nil
       end
 
       it "gets its color" do
-        label.color.should_not be_nil
+        expect(label.color).to_not be_nil
       end
     end
 
     context "boards" do
       it "has a board" do
-        client.stub(:get).with("/boards/abcdef123456789123456789", {}).and_return JSON.generate(boards_details.first)
-        label.board.should_not be_nil
+        expect(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789", {})
+          .and_return JSON.generate(boards_details.first)
+
+        expect(label.board).to_not be_nil
       end
     end
   end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -8,20 +8,30 @@ module Trello
     let(:client) { Client.new }
 
     before(:each) do
-      client.stub(:get).with('/lists/abcdef123456789123456789', {}).and_return JSON.generate(lists_details.first)
-      client.stub(:get).with('/boards/abcdef123456789123456789', {}).and_return JSON.generate(boards_details.first)
+      allow(client)
+        .to receive(:get)
+        .with('/lists/abcdef123456789123456789', {})
+        .and_return JSON.generate(lists_details.first)
+
+      allow(client)
+        .to receive(:get)
+        .with('/boards/abcdef123456789123456789', {})
+        .and_return JSON.generate(boards_details.first)
     end
 
     context 'finding' do
       let(:client) { Trello.client }
 
       it 'delegates to client#find' do
-        client.should_receive(:find).with(:list, 'abcdef123456789123456789', {})
+        expect(client)
+          .to receive(:find)
+          .with(:list, 'abcdef123456789123456789', {})
+
         List.find('abcdef123456789123456789')
       end
 
       it 'is equivalent to client#find' do
-        List.find('abcdef123456789123456789').should eq(list)
+        expect(List.find('abcdef123456789123456789')).to eq(list)
       end
     end
 
@@ -30,17 +40,17 @@ module Trello
 
       it 'creates a new record' do
         list = List.new(lists_details.first)
-        list.should be_valid
+        expect(list).to be_valid
       end
 
       it 'must not be valid if not given a name' do
         list = List.new(lists_details.first.except('name'))
-        list.should_not be_valid
+        expect(list).to_not be_valid
       end
 
       it 'must not be valid if not given a list id' do
         list = List.new(lists_details.first.except('id'))
-        list.should_not be_valid
+        expect(list).to_not be_valid
       end
 
       it 'creates a new record and saves it on Trello', refactor: true do
@@ -54,11 +64,12 @@ module Trello
 
         expected_payload = {name: 'Test List', closed: false, idBoard: 'abcdef123456789123456789', pos: 42}
 
-        client.should_receive(:post).with('/lists', expected_payload).and_return result
+        expect(client)
+          .to receive(:post)
+          .with('/lists', expected_payload).and_return result
 
         list = List.create(payload)
-
-        list.class.should be List
+        expect(list).to be_a List
       end
     end
 
@@ -72,7 +83,11 @@ module Trello
           pos: list.pos
         }
 
-        client.should_receive(:put).once.with('/lists/abcdef123456789123456789', payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with('/lists/abcdef123456789123456789', payload)
+
         list.name = expected_new_name
         list.save
       end
@@ -85,7 +100,11 @@ module Trello
           pos: new_position
         }
 
-        client.should_receive(:put).once.with('/lists/abcdef123456789123456789', payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with('/lists/abcdef123456789123456789', payload)
+
         list.pos = new_position
         list.save
       end
@@ -93,67 +112,82 @@ module Trello
 
     context 'fields' do
       it 'gets its id' do
-        list.id.should == lists_details.first['id']
+        expect(list.id).to eq lists_details.first['id']
       end
 
       it 'gets its name' do
-        list.name.should == lists_details.first['name']
+        expect(list.name).to eq lists_details.first['name']
       end
 
       it 'knows if it is open or closed' do
-        list.closed.should == lists_details.first['closed']
+        expect(list.closed).to eq lists_details.first['closed']
       end
 
       it 'has a board' do
-        list.board.should == Board.new(boards_details.first)
+        expect(list.board).to eq Board.new(boards_details.first)
       end
 
       it 'gets its position' do
-        list.pos.should == lists_details.first['pos']
+        expect(list.pos).to eq lists_details.first['pos']
       end
     end
 
     context 'actions' do
       it 'has a list of actions' do
-        client.stub(:get).with('/lists/abcdef123456789123456789/actions', { filter: :all }).and_return actions_payload
-        list.actions.count.should be > 0
+        allow(client)
+          .to receive(:get)
+          .with('/lists/abcdef123456789123456789/actions', { filter: :all })
+          .and_return actions_payload
+
+        expect(list.actions.count).to be > 0
       end
     end
 
     context 'cards' do
       it 'has a list of cards' do
-        client.stub(:get).with('/lists/abcdef123456789123456789/cards', { filter: :open }).and_return cards_payload
-        list.cards.count.should be > 0
+        allow(client)
+          .to receive(:get)
+          .with('/lists/abcdef123456789123456789/cards', { filter: :open })
+          .and_return cards_payload
+
+        expect(list.cards.count).to be > 0
       end
 
       it 'moves cards to another list' do
         other_list = List.new(lists_details.first.merge(id: 'otherListID', cards: []))
 
-        client.stub(:post).with('/lists/abcdef123456789123456789/moveAllCards', { idBoard: other_list.board_id, idList: other_list.id }).and_return cards_payload
-        list.move_all_cards(other_list).should eq cards_payload
+        allow(client)
+          .to receive(:post)
+          .with('/lists/abcdef123456789123456789/moveAllCards', { idBoard: other_list.board_id, idList: other_list.id })
+          .and_return cards_payload
+
+        expect(list.move_all_cards(other_list)).to eq cards_payload
       end
     end
 
     describe '#closed?' do
       it 'returns the closed attribute' do
-        expect(list.closed?).not_to be(true)
+        expect(list).to_not be_closed
       end
     end
 
     describe '#close' do
       it 'updates the close attribute to true' do
         list.close
-        expect(list.closed).to be(true)
+        expect(list).to be_closed
       end
     end
 
     describe '#close!' do
       it 'updates the close attribute to true and saves the list' do
-        client.should_receive(:put).once.with('/lists/abcdef123456789123456789', {
-          name: list.name,
-          closed: true,
-          pos: list.pos
-        })
+        expect(client)
+          .to receive(:put)
+          .once
+          .with('/lists/abcdef123456789123456789', {
+            name: list.name,
+            closed: true,
+            pos: list.pos
+          })
 
         list.close!
       end

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -8,79 +8,114 @@ module Trello
     let(:member) { client.find(:member, "abcdef123456789012345678") }
     let(:client) { Client.new }
 
-    before(:each) do
-      client.stub(:get).with("/members/abcdef123456789012345678", {}).and_return user_payload
-      client.stub(:get).with("/members/abcdef123456789012345678/notifications", {}).and_return "[" << notification_payload << "]"
+    before do
+      allow(client)
+        .to receive(:get)
+        .with("/members/abcdef123456789012345678", {})
+        .and_return user_payload
+
+      allow(client)
+        .to receive(:get)
+        .with("/members/abcdef123456789012345678/notifications", {})
+        .and_return("[" << notification_payload << "]")
     end
 
     context "finding" do
       let(:client) { Trello.client }
 
       it "can find a specific notification" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}", {}).and_return notification_payload
-        Notification.find(notification_details['id']).should == notification
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}", {})
+          .and_return notification_payload
+
+        expect(Notification.find(notification_details['id'])).to eq notification
       end
     end
 
     context "boards" do
       it "can retrieve the board" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}/board").and_return JSON.generate(boards_details.first)
-        notification.board.id.should == boards_details.first['id']
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}/board")
+          .and_return JSON.generate(boards_details.first)
+
+        expect(notification.board.id).to eq boards_details.first['id']
       end
     end
 
     context "lists" do
       it "can retrieve the list" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}/list").and_return JSON.generate(lists_details.first)
-        notification.list.id.should == lists_details.first['id']
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}/list")
+          .and_return JSON.generate(lists_details.first)
+
+        expect(notification.list.id).to eq lists_details.first['id']
       end
     end
 
     context "cards" do
       it "can retrieve the card" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}/card").and_return JSON.generate(cards_details.first)
-        notification.card.id.should == cards_details.first['id']
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}/card")
+          .and_return JSON.generate(cards_details.first)
+
+        expect(notification.card.id).to eq cards_details.first['id']
       end
     end
 
     context "members" do
       it "can retrieve the member" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}/member").and_return user_payload
-        notification.member.id.should == user_details['id']
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}/member")
+          .and_return user_payload
+
+        expect(notification.member.id).to eq user_details['id']
       end
 
       it "can retrieve the member creator" do
-        client.stub(:get).with("/members/#{user_details['id']}", {}).and_return user_payload
-        notification.member_creator.id.should == user_details['id']
+        allow(client)
+          .to receive(:get)
+          .with("/members/#{user_details['id']}", {})
+          .and_return user_payload
+
+        expect(notification.member_creator.id).to eq user_details['id']
       end
     end
 
     context "organization" do
       it "can retrieve the organization" do
-        client.stub(:get).with("/notifications/#{notification_details['id']}/organization").and_return JSON.generate(orgs_details.first)
-        notification.organization.id.should == orgs_details.first['id']
+        allow(client)
+          .to receive(:get)
+          .with("/notifications/#{notification_details['id']}/organization")
+          .and_return JSON.generate(orgs_details.first)
+
+        expect(notification.organization.id).to eq orgs_details.first['id']
       end
     end
 
     context "local" do
       it "gets the read status" do
-        notification.unread?.should == notification_details['unread']
+        expect(notification.unread?).to eq notification_details['unread']
       end
 
       it "gets the type" do
-        notification.type.should == notification_details['type']
+        expect(notification.type).to eq notification_details['type']
       end
 
       it "gets the date" do
-        notification.date.should == notification_details['date']
+        expect(notification.date).to eq notification_details['date']
       end
 
       it "gets the data" do
-        notification.data.should == notification_details['data']
+        expect(notification.data).to eq notification_details['data']
       end
 
       it "gets the member creator id" do
-        notification.member_creator_id.should == notification_details['idMemberCreator']
+        expect(notification.member_creator_id).to eq notification_details['idMemberCreator']
       end
     end
   end

--- a/spec/oauth_policy_spec.rb
+++ b/spec/oauth_policy_spec.rb
@@ -72,8 +72,14 @@ describe OAuthPolicy do
       uri = Addressable::URI.parse('https://xxx/?name=Riccardo')
       request = Request.new :get, uri
 
-      Clock.stub(:timestamp).and_return '1327048592'
-      Nonce.stub(:next).and_return 'b94ff2bf7f0a5e87a326064ae1dbb18f'
+      allow(Clock)
+        .to receive(:timestamp)
+        .and_return '1327048592'
+
+      allow(Nonce)
+        .to receive(:next)
+        .and_return 'b94ff2bf7f0a5e87a326064ae1dbb18f'
+
       OAuthPolicy.consumer_credential = OAuthCredential.new 'consumer_key', 'consumer_secret'
       OAuthPolicy.token               = OAuthCredential.new 'token', nil
 
@@ -84,8 +90,13 @@ describe OAuthPolicy do
     end
 
     it 'adds the correct signature as part of authorization header' do
-      Clock.stub(:timestamp).and_return '1327048592'
-      Nonce.stub(:next).and_return 'b94ff2bf7f0a5e87a326064ae1dbb18f'
+      allow(Clock)
+        .to receive(:timestamp)
+        .and_return '1327048592'
+
+      allow(Nonce)
+        .to receive(:next)
+        .and_return 'b94ff2bf7f0a5e87a326064ae1dbb18f'
 
       OAuthPolicy.consumer_credential = OAuthCredential.new 'consumer_key', 'consumer_secret'
       OAuthPolicy.token               = OAuthCredential.new 'token', nil
@@ -98,8 +109,13 @@ describe OAuthPolicy do
     end
 
     it 'adds correct signature for uri with parameters' do
-      Clock.stub(:timestamp).and_return '1327351010'
-      Nonce.stub(:next).and_return 'f5474aaf44ca84df0b09870044f91c69'
+      allow(Clock)
+        .to receive(:timestamp)
+        .and_return '1327351010'
+
+      allow(Nonce)
+        .to receive(:next)
+        .and_return 'f5474aaf44ca84df0b09870044f91c69'
 
       OAuthPolicy.consumer_credential = OAuthCredential.new 'consumer_key', 'consumer_secret'
       OAuthPolicy.token               = OAuthCredential.new 'token', nil
@@ -120,8 +136,13 @@ describe OAuthPolicy do
     end
 
     it 'can sign with token' do
-      Clock.stub(:timestamp).and_return '1327360530'
-      Nonce.stub(:next).and_return '4f610cb28e7aa8711558de5234af1f0e'
+      allow(Clock)
+        .to receive(:timestamp)
+        .and_return '1327360530'
+
+      allow(Nonce)
+        .to receive(:next)
+        .and_return '4f610cb28e7aa8711558de5234af1f0e'
 
       OAuthPolicy.consumer_credential = OAuthCredential.new 'consumer_key', 'consumer_secret'
       OAuthPolicy.token  = OAuthCredential.new 'token_key', 'token_secret'

--- a/spec/oauth_policy_spec.rb
+++ b/spec/oauth_policy_spec.rb
@@ -12,8 +12,8 @@ describe OAuthPolicy do
   describe '#consumer_credential' do
     it 'uses class setting if available' do
       policy = OAuthPolicy.new
-      policy.consumer_credential.key.should eq('xxx')
-      policy.consumer_credential.secret.should eq('xxx')
+      expect(policy.consumer_credential.key).to eq('xxx')
+      expect(policy.consumer_credential.secret).to eq('xxx')
     end
 
     it 'is built from given consumer_key and consumer_secret' do
@@ -21,14 +21,14 @@ describe OAuthPolicy do
         consumer_key: 'consumer_key',
         consumer_secret: 'consumer_secret'
       )
-      policy.consumer_credential.key.should eq('consumer_key')
-      policy.consumer_credential.secret.should eq('consumer_secret')
+      expect(policy.consumer_credential.key).to eq('consumer_key')
+      expect(policy.consumer_credential.secret).to eq('consumer_secret')
     end
 
     it 'is nil if none supplied to class' do
       OAuthPolicy.consumer_credential = nil
       policy = OAuthPolicy.new
-      policy.consumer_credential.should be_nil
+      expect(policy.consumer_credential).to be_nil
     end
   end
 
@@ -36,8 +36,8 @@ describe OAuthPolicy do
     it 'uses class setting if available' do
       OAuthPolicy.token = OAuthCredential.new 'xxx', 'xxx'
       policy = OAuthPolicy.new
-      policy.token.key.should eq('xxx')
-      policy.token.secret.should eq('xxx')
+      expect(policy.token.key).to eq('xxx')
+      expect(policy.token.secret).to eq('xxx')
     end
 
     it 'is built from given oauth_token and oauth_token_secret' do
@@ -45,13 +45,13 @@ describe OAuthPolicy do
         oauth_token: 'oauth_token',
         oauth_token_secret: 'oauth_token_secret'
       )
-      policy.token.key.should eq('oauth_token')
-      policy.token.secret.should eq('oauth_token_secret')
+      expect(policy.token.key).to eq('oauth_token')
+      expect(policy.token.secret).to eq('oauth_token_secret')
     end
 
     it 'is an empty token if no oauth credentials supplied' do
       policy = OAuthPolicy.new
-      policy.token.should be_nil
+      expect(policy.token).to be_nil
     end
   end
 
@@ -65,7 +65,7 @@ describe OAuthPolicy do
 
       authorized_request = OAuthPolicy.authorize request
 
-      authorized_request.headers.keys.should include 'Authorization'
+      expect(authorized_request.headers.keys).to include 'Authorization'
     end
 
     it 'preserves query parameters' do
@@ -80,7 +80,7 @@ describe OAuthPolicy do
       authorized_request = OAuthPolicy.authorize request
 
       the_query_parameters = Addressable::URI.parse(authorized_request.uri).query_values
-      the_query_parameters.should == {'name' => 'Riccardo'}
+      expect(the_query_parameters).to eq({'name' => 'Riccardo'})
     end
 
     it 'adds the correct signature as part of authorization header' do
@@ -94,7 +94,7 @@ describe OAuthPolicy do
 
       authorized_request = OAuthPolicy.authorize request
 
-      authorized_request.headers['Authorization'].should =~ /oauth_signature="TVNk%2FCs03FHqutDUqn05%2FDkvVek%3D"/
+      expect(authorized_request.headers['Authorization']).to match(/oauth_signature="TVNk%2FCs03FHqutDUqn05%2FDkvVek%3D"/)
     end
 
     it 'adds correct signature for uri with parameters' do
@@ -108,7 +108,7 @@ describe OAuthPolicy do
 
       authorized_request = OAuthPolicy.authorize request
 
-      authorized_request.headers['Authorization'].should =~ /oauth_signature="DprU1bdbNdJQ40UhD4n7wRR9jts%3D"/
+      expect(authorized_request.headers['Authorization']).to match(/oauth_signature="DprU1bdbNdJQ40UhD4n7wRR9jts%3D"/)
     end
 
     it 'fails if consumer_credential is unset' do
@@ -116,7 +116,7 @@ describe OAuthPolicy do
 
       request = Request.new :get, Addressable::URI.parse('http://xxx/')
 
-      -> { OAuthPolicy.authorize request }.should raise_error 'The consumer_credential has not been supplied.'
+      expect { OAuthPolicy.authorize request }.to raise_error 'The consumer_credential has not been supplied.'
     end
 
     it 'can sign with token' do
@@ -130,7 +130,7 @@ describe OAuthPolicy do
 
       authorized_request = OAuthPolicy.authorize request
 
-      authorized_request.headers['Authorization'].should =~ /oauth_signature="1Boj4fo6KiXA4xGD%2BKF5QOD36PI%3D"/
+      expect(authorized_request.headers['Authorization']).to match(/oauth_signature="1Boj4fo6KiXA4xGD%2BKF5QOD36PI%3D"/)
     end
 
     it 'adds correct signature for https uri'

--- a/spec/organization_spec.rb
+++ b/spec/organization_spec.rb
@@ -1,4 +1,3 @@
-
 require 'spec_helper'
 
 module Trello
@@ -8,28 +7,37 @@ module Trello
     let(:organization) { client.find(:organization, '4ee7e59ae582acdec8000291') }
     let(:client) { Client.new }
 
-    before(:each) do
-      client.stub(:get).with('/organizations/4ee7e59ae582acdec8000291', {}).
-        and_return organization_payload
+    before do
+      allow(client)
+        .to receive(:get)
+        .with('/organizations/4ee7e59ae582acdec8000291', {})
+        .and_return organization_payload
     end
 
     context 'finding' do
       let(:client) { Trello.client }
 
       it 'delegates to Trello.client#find' do
-        client.should_receive(:find).with(:organization, '4ee7e59ae582acdec8000291', {})
+        expect(client)
+          .to receive(:find)
+          .with(:organization, '4ee7e59ae582acdec8000291', {})
+
         Organization.find('4ee7e59ae582acdec8000291')
       end
 
       it 'is equivalent to client#find' do
-        Organization.find('4ee7e59ae582acdec8000291').should eq(organization)
+        expect(Organization.find('4ee7e59ae582acdec8000291')).to eq(organization)
       end
     end
 
     context 'actions' do
       it 'retrieves actions' do
-        client.stub(:get).with('/organizations/4ee7e59ae582acdec8000291/actions', { filter: :all }).and_return actions_payload
-        organization.actions.count.should be > 0
+        allow(client)
+          .to receive(:get)
+          .with('/organizations/4ee7e59ae582acdec8000291/actions', { filter: :all })
+          .and_return actions_payload
+
+        expect(organization.actions.count).to be > 0
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
 require 'rubygems'
+
 unless defined? Rubinius
   require 'simplecov'
   SimpleCov.start
+end
+
+begin
+  require 'pry-byebug'
+rescue LoadError
 end
 
 # Set up gems listed in the Gemfile.

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -16,14 +16,17 @@ describe String, '#json_into' do
   end
 
   it 'converts json into an instance of a class' do
-    '{}'.json_into(example_class).should be_an_instance_of example_class
+    expect('{}'.json_into(example_class)).to be_a example_class
   end
 
   it 'supplies the parsed json to the class ctor as a hash' do
-    example_class.should_receive(:new).once.with({
-      "name"        => "Jazz Kang",
-      "description" => "Plonker"
-    })
+    expect(example_class)
+      .to receive(:new)
+      .once
+      .with({
+        "name"        => "Jazz Kang",
+        "description" => "Plonker"
+      })
 
     json_text = '{"name" : "Jazz Kang", "description": "Plonker"}'
 
@@ -40,10 +43,10 @@ describe String, '#json_into' do
 
     result = json_text.json_into example_class
 
-    result.should be_an Array
-    result.size.should == 2
+    expect(result).to be_an Array
+    expect(result.size).to eq 2
     result.each do |parsed|
-      parsed.should be_an_instance_of example_class
+      expect(parsed).to be_a example_class
     end
   end
 end

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -7,43 +7,63 @@ module Trello
     let(:token) { client.find(:token, '1234') }
     let(:client) { Client.new }
 
-    before(:each) do
-      client.stub(:get).with('/tokens/1234', {}).and_return token_payload
+    before do
+      allow(client)
+        .to receive(:get)
+        .with('/tokens/1234', {})
+        .and_return token_payload
     end
 
     context 'finding' do
       let(:client) { Trello.client }
 
       it 'delegates to Trello.client#find' do
-        client.should_receive(:find).with(:token, '1234', {webhooks: true})
+        expect(client)
+          .to receive(:find)
+          .with(:token, '1234', {webhooks: true})
+
         Token.find('1234')
       end
 
       it 'is equivalent to client#find' do
-        Token.find('1234', {}).should eq(token)
+        expect(Token.find('1234', {})).to eq(token)
       end
     end
 
     context 'attributes' do
       it 'has an id' do
-        token.id.should == '4f2c10c7b3eb95a45b294cd5'
+        expect(token.id).to eq '4f2c10c7b3eb95a45b294cd5'
       end
 
       it 'gets its created_at date' do
-        token.created_at.should == Time.iso8601('2012-02-03T16:52:23.661Z')
+        expect(token.created_at).to eq Time.iso8601('2012-02-03T16:52:23.661Z')
       end
 
       it 'has a permission grant' do
-        token.permissions.count.should be 3
+        expect(token.permissions.count).to eq 3
       end
     end
 
     context 'members' do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/members/abcdef123456789123456789', {})
+          .and_return user_payload
+
+        allow(Trello.client)
+          .to receive(:get)
+          .with('/members/abcdef123456789123456789', {})
+          .and_return user_payload
+
+        allow(client)
+          .to receive(:get)
+          .with('/tokens/1234', {})
+          .and_return token_payload
+      end
+
       it 'retrieves the member who authorized the token' do
-        client.stub(:get).with('/members/abcdef123456789123456789', {}).and_return user_payload
-        Trello.client.stub(:get).with('/members/abcdef123456789123456789', {}).and_return user_payload
-        client.stub(:get).with('/tokens/1234', {}).and_return token_payload
-        token.member.should == Member.find('abcdef123456789123456789')
+        expect(token.member).to eq Member.find('abcdef123456789123456789')
       end
     end
   end

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -14,7 +14,7 @@ describe Trello do
     end
 
     it 'builds auth policy client uses to make requests' do
-      TInternet.stub(:execute)
+      allow(TInternet).to receive(:execute)
       expect(Trello.auth_policy).to receive(:authorize)
       Trello.client.get(:member, params = {})
     end

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -6,27 +6,24 @@ include Trello::Authorization
 describe Trello do
 
   describe 'self.configure' do
-    it 'builds auth policy client uses to make requests' do
+    before do
       Trello.configure do |config|
         config.developer_public_key = 'developer_public_key'
         config.member_token         = 'member_token'
       end
+    end
 
+    it 'builds auth policy client uses to make requests' do
       TInternet.stub(:execute)
-      Trello.auth_policy.should_receive(:authorize)
+      expect(Trello.auth_policy).to receive(:authorize)
       Trello.client.get(:member, params = {})
     end
 
     it 'configures basic auth policy' do
-      Trello.configure do |config|
-        config.developer_public_key = 'developer_public_key'
-        config.member_token         = 'member_token'
-      end
-
       auth_policy = Trello.auth_policy
-      auth_policy.should be_a(BasicAuthPolicy)
-      auth_policy.developer_public_key.should eq('developer_public_key')
-      auth_policy.member_token.should eq('member_token')
+      expect(auth_policy).to be_a(BasicAuthPolicy)
+      expect(auth_policy.developer_public_key).to eq('developer_public_key')
+      expect(auth_policy.member_token).to eq('member_token')
     end
 
     context 'oauth' do
@@ -42,16 +39,16 @@ describe Trello do
       it 'configures oauth policy' do
         auth_policy = Trello.auth_policy
 
-        auth_policy.should be_a(OAuthPolicy)
-        auth_policy.consumer_key.should eq('consumer_key')
-        auth_policy.consumer_secret.should eq('consumer_secret')
-        auth_policy.oauth_token.should eq('oauth_token')
-        auth_policy.oauth_token_secret.should eq('oauth_token_secret')
+        expect(auth_policy).to be_a(OAuthPolicy)
+        expect(auth_policy.consumer_key).to eq('consumer_key')
+        expect(auth_policy.consumer_secret).to eq('consumer_secret')
+        expect(auth_policy.oauth_token).to eq('oauth_token')
+        expect(auth_policy.oauth_token_secret).to eq('oauth_token_secret')
       end
 
       it 'updates auth policy configuration' do
         auth_policy = Trello.auth_policy
-        auth_policy.consumer_key.should eq('consumer_key')
+        expect(auth_policy.consumer_key).to eq('consumer_key')
 
         Trello.configure do |config|
           config.consumer_key     = 'new_consumer_key'
@@ -62,11 +59,11 @@ describe Trello do
 
         auth_policy = Trello.auth_policy
 
-        auth_policy.should be_a(OAuthPolicy)
-        auth_policy.consumer_key.should eq('new_consumer_key')
-        auth_policy.consumer_secret.should eq('new_consumer_secret')
-        auth_policy.oauth_token.should eq('new_oauth_token')
-        auth_policy.oauth_token_secret.should be_nil
+        expect(auth_policy).to be_a(OAuthPolicy)
+        expect(auth_policy.consumer_key).to eq('new_consumer_key')
+        expect(auth_policy.consumer_secret).to eq('new_consumer_secret')
+        expect(auth_policy.oauth_token).to eq('new_oauth_token')
+        expect(auth_policy.oauth_token_secret).to be_nil
       end
     end
 
@@ -75,7 +72,7 @@ describe Trello do
         Trello.configure
       end
 
-      it { Trello.auth_policy.should be_a(AuthPolicy) }
+      it { expect(Trello.auth_policy).to be_a(AuthPolicy) }
       it { expect { Trello.client.get(:member) }.to raise_error(Trello::ConfigurationError) }
     end
 

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -8,19 +8,25 @@ module Trello
     let(:client) { Client.new }
 
     before(:each) do
-      client.stub(:get).with("/webhooks/1234", {}).and_return webhook_payload
+      allow(client)
+        .to receive(:get)
+        .with("/webhooks/1234", {})
+        .and_return webhook_payload
     end
 
     context "finding" do
       let(:client) { Trello.client }
 
       it "delegates to Trello.client#find" do
-        client.should_receive(:find).with(:webhook, '1234', {})
+        expect(client)
+          .to receive(:find)
+          .with(:webhook, '1234', {})
+
         Webhook.find('1234')
       end
 
       it "is equivalent to client#find" do
-        Webhook.find('1234').should eq(webhook)
+        expect(Webhook.find('1234')).to eq(webhook)
       end
     end
 
@@ -29,7 +35,7 @@ module Trello
 
       it "creates a new webhook" do
         webhook = Webhook.new(webhooks_details.first)
-        webhook.should be_valid
+        expect(webhook).to be_valid
       end
 
       it 'creates a new webhook and saves it on Trello', refactor: true do
@@ -40,11 +46,14 @@ module Trello
 
         expected_payload = {description: webhook[:description], idModel: webhook[:idModel], callbackURL: webhook[:callbackURL]}
 
-        client.should_receive(:post).with("/webhooks", expected_payload).and_return result
+        expect(client)
+          .to receive(:post)
+          .with("/webhooks", expected_payload)
+          .and_return result
 
         webhook = Webhook.create(webhooks_details.first)
 
-        webhook.class.should be Webhook
+        expect(webhook.class).to be Webhook
       end
     end
 
@@ -54,7 +63,10 @@ module Trello
 
         expected_payload = {description: expected_new_description, idModel: webhook.id_model, callbackURL: webhook.callback_url, active: webhook.active}
 
-        client.should_receive(:put).once.with("/webhooks/#{webhook.id}", expected_payload)
+        expect(client)
+          .to receive(:put)
+          .once
+          .with("/webhooks/#{webhook.id}", expected_payload)
 
         webhook.description = expected_new_description
         webhook.save
@@ -63,14 +75,17 @@ module Trello
 
     context "deleting" do
       it "deletes the webhook" do
-        client.should_receive(:delete).with("/webhooks/#{webhook.id}")
+        expect(client)
+          .to receive(:delete)
+          .with("/webhooks/#{webhook.id}")
+
         webhook.delete
       end
     end
 
     context "activated?" do
       it "returns the active attribute" do
-        expect(webhook.activated?).to be(true)
+        expect(webhook).to be_activated
       end
     end
   end


### PR DESCRIPTION
I'm working on migrating current specs to utilize the `expect` syntax over `should`.  Components of the migration include...

1. Replace `object.value.should == 'expected'` with `expect(object.value).to eq 'expected'`
3. Replace `object.should_receive(:method)` with `expect(object).to receive(:method)`
1. Replace `object.stub(:method)` with `allow(object).to receive(:method)`
2. Move stubs to a `before` block and out of the `it` expectation blocks
4. In certain cases, DRY-up specs by extract common values into `let` and use `context` blocks to redefine a value, without duplicating the stub.
5. Utilize RSpec's support for predicate methods: `expect(object.valid?).to be(true)` to `expect(object).to be_valid`