### PR TITLE
Bump minimum version of Ruby to 2.0

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.summary           = %q{A wrapper around the trello.com API.}
   s.test_files        = Dir.glob("spec/**/*")
 
-  s.required_rubygems_version = ">= 1.3.6"
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'activemodel', '>= 3.2.0'
   s.add_dependency 'addressable', '~> 2.3'


### PR DESCRIPTION
Since we dropped support for EOL 1.9.3