### PR TITLE
Pass default label limit of the max 1000

### DIFF
--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -155,7 +155,12 @@ module Trello
     # Returns a reference to the organization this board belongs to.
     one :organization, path: :organizations, using: :organization_id
 
-    many :labels
+    def labels(params={})
+      # Set the limit to as high as possible given there is no pagination in this API.
+      params[:limit] = 1000 unless params[:limit]
+      labels = client.get("/boards/#{id}/labels", params).json_into(Label)
+      MultiAssociation.new(self, labels).proxy
+    end
 
     def label_names
       label_names = client.get("/boards/#{id}/labelnames").json_into(LabelName)

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -178,7 +178,7 @@ module Trello
     end
 
     many :labels
-    
+
     # Returns a reference to the list this card is currently in.
     one :list, path: :lists, using: :list_id
 
@@ -315,7 +315,7 @@ module Trello
     def remove_member(member)
       client.delete("/cards/#{id}/members/#{member.id}")
     end
-    
+
     # Add a label
     def add_label(label)
       unless label.valid?
@@ -327,11 +327,11 @@ module Trello
 
     # Remove a label
     def remove_label(label)
-        unless label.valid?
-          errors.add(:label, "is not valid.")
-          return Trello.logger.warn "Label is not valid." unless label.valid?
-        end
-        client.delete("/cards/#{id}/idLabels/#{label.id}")
+      unless label.valid?
+        errors.add(:label, "is not valid.")
+        return Trello.logger.warn "Label is not valid." unless label.valid?
+      end
+      client.delete("/cards/#{id}/idLabels/#{label.id}")
     end
 
     # Add an attachment to this card

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -124,7 +124,7 @@ module Trello
       end
 
       it "gets the specific labels for the board" do
-        client.stub(:get).with("/boards/abcdef123456789123456789/labels", {}).
+        client.stub(:get).with("/boards/abcdef123456789123456789/labels", {:limit => 1000}).
           and_return label_payload
         labels = board.labels
         labels.count.should eq(4)
@@ -139,6 +139,12 @@ module Trello
         expect(labels[3].board_id).to  eq('abcdef123456789123456789')
         expect(labels[3].name).to  eq('on hold')
         expect(labels[3].uses).to  eq(6)
+      end
+
+      it "passes the label limit" do
+        client.stub(:get).with("/boards/abcdef123456789123456789/labels", {:limit => 50}).
+          and_return label_payload
+        labels = board.labels(:limit => 50)
       end
     end
 


### PR DESCRIPTION
The Trello API returns 50 board labels max by default:

https://developers.trello.com/advanced-reference/board#get-1-boards-board-id-labels

There is currently no recognition of this in the ruby-trello and it looks like you are getting all the labels.  This can be quite dangerous to script against because you potentially won't see all the labels that exist.

I am not sure of the best way to make this change.  Suggestions welcome.  But I think the most important part is that the default limit isn't left at 50 without an indication to the caller that they aren't getting all the labels.