### PR TITLE
Authorization convenience methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :development, :spec do
   gem 'rspec', '~> 3.3.0'
   gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
   gem 'webmock'
+  gem 'launchy'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby Trello API
 
-[![Stories in Ready](http://badge.waffle.io/jeremytregunna/ruby-trello.png)](http://waffle.io/jeremytregunna/ruby-trello)  
+[![Stories in Ready](http://badge.waffle.io/jeremytregunna/ruby-trello.png)](http://waffle.io/jeremytregunna/ruby-trello)
 [![Build Status](https://secure.travis-ci.org/jeremytregunna/ruby-trello.png)](http://travis-ci.org/jeremytregunna/ruby-trello) [![Dependency Status](https://gemnasium.com/jeremytregunna/ruby-trello.png)](https://gemnasium.com/jeremytregunna/ruby-trello.png)
 [![Code Climate](https://codeclimate.com/github/jeremytregunna/ruby-trello/badges/gpa.svg)](https://codeclimate.com/github/jeremytregunna/ruby-trello)
 
@@ -26,16 +26,17 @@ Supports Ruby 2.0 or newer. Version 1.3.0 is the last version that supports Ruby
 
 ####Basic authorization:
 
-1. Get your API keys from [trello.com/app-key](https://trello.com/app-key).
-2. Visit the URL [trello.com/1/authorize], with the following GET parameters:
-    - `key`: the API key you got in step 1.
-    - `response_type`: "token"
-    - `expiration`: "never" if you don't want your token to ever expire. If you leave this blank,
-       your generated token will expire after 30 days.
-    - `scope`: "read,write" (optional) by default the API key will only give read access.  You must set the scope to "read,write" if you would like ruby-trello to have permissions to create and delete.
-    - The URL will look like this:
-      `https://trello.com/1/authorize?key=YOURAPIKEY&response_type=token&expiration=never&scope=read,write`
-3. You should see a page asking you to authorize your Trello application. Click "allow" and you should see a second page with a long alphanumeric string. This is your member token.
+1. Get your API public key from Trello via the irb console:
+
+```
+$ gem install trello
+$ irb -rubygems
+irb> require 'trello'
+irb> Trello.open_public_key_url                         # copy your public key
+irb> Trello.open_authorization_url key: 'yourpublickey' # copy your member token
+```
+
+2. You can now use the public key and member token in your app code:
 
 ```ruby
 require 'trello'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -107,7 +107,7 @@ module Trello
 
   # Url to Trello API public key page
   def self.public_key_url
-    "https://trello.com/app-key"
+    'https://trello.com/app-key'
   end
 
   # Url to token for making authorized requests to the Trello API
@@ -116,21 +116,21 @@ module Trello
   # @param options [Hash] Repository information to update
   # @option options [String] :name Name of the application
   # @option options [String] :key Application key
-  # @option options [String] :response_type "token"
-  # @option options [String] :callback_method "postMessage" or "fragment"
+  # @option options [String] :response_type 'token'
+  # @option options [String] :callback_method 'postMessage' or 'fragment'
   # @option options [String] :return_url URL the token should be returned to
-  # @option options [String] :scope Comma-separated list of one or more of "read", "write", "account"
-  # @option options [String] :expiration "1hour", "1day", "30days", "never"
+  # @option options [String] :scope Comma-separated list of one or more of 'read', 'write', 'account'
+  # @option options [String] :expiration '1hour', '1day', '30days', 'never'
   # @see https://developers.trello.com/authorize
   def self.authorize_url(options = {})
     params = options.dup
     params[:key] ||= configuration.developer_public_key or
-      raise ArgumentError, "Please configure your Trello public key"
-    params[:name] ||= "Ruby Trello"
-    params[:scope] = "read,write,account"
-    params[:expiration] ||= "never"
-    params[:response_type] ||= "token"
-    uri = Addressable::URI.parse "https://trello.com/1/authorize"
+      raise ArgumentError, 'Please configure your Trello public key'
+    params[:name] ||= 'Ruby Trello'
+    params[:scope] = 'read,write,account'
+    params[:expiration] ||= 'never'
+    params[:response_type] ||= 'token'
+    uri = Addressable::URI.parse 'https://trello.com/1/authorize'
     uri.query_values = params
     uri
   end
@@ -151,10 +151,10 @@ module Trello
 
   # @private
   def self.open_url(url)
-    require "launchy"
+    require 'launchy'
     Launchy.open(url.to_s)
   rescue LoadError
-    warn "Please install the launchy gem to open the url automatically."
+    warn 'Please install the launchy gem to open the url automatically.'
     url
   end
 end

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -1,8 +1,8 @@
-
 require 'oauth'
 require 'json'
 require 'logger'
 require 'active_model'
+require 'addressable/uri'
 
 # Ruby wrapper around the Trello[http://trello.com] API
 #
@@ -104,4 +104,57 @@ module Trello
 
   def self.auth_policy; client.auth_policy; end
   def self.configuration; client.configuration; end
+
+  # Url to Trello API public key page
+  def self.public_key_url
+    "https://trello.com/app-key"
+  end
+
+  # Url to token for making authorized requests to the Trello API
+  #
+  # @param [String, #read] contents the contents to reverse
+  # @param options [Hash] Repository information to update
+  # @option options [String] :name Name of the application
+  # @option options [String] :key Application key
+  # @option options [String] :response_type "token"
+  # @option options [String] :callback_method "postMessage" or "fragment"
+  # @option options [String] :return_url URL the token should be returned to
+  # @option options [String] :scope Comma-separated list of one or more of "read", "write", "account"
+  # @option options [String] :expiration "1hour", "1day", "30days", "never"
+  # @see https://developers.trello.com/authorize
+  def self.authorize_url(options = {})
+    params = options.dup
+    params[:key] ||= configuration.developer_public_key or
+      raise ArgumentError, "Please configure your Trello public key"
+    params[:name] ||= "Ruby Trello"
+    params[:scope] = "read,write,account"
+    params[:expiration] ||= "never"
+    params[:response_type] ||= "token"
+    uri = Addressable::URI.parse "https://trello.com/1/authorize"
+    uri.query_values = params
+    uri
+  end
+
+  # Visit the Trello API public key page
+  #
+  # @see https://trello.com/app-key
+  def self.open_public_key_url
+    open_url public_key_url
+  end
+
+  # Visit the Trello authorized token page
+  #
+  # @see https://developers.trello.com/authorize
+  def self.open_authorization_url(options = {})
+    open_url authorize_url(options)
+  end
+
+  # @private
+  def self.open_url(url)
+    require "launchy"
+    Launchy.open(url.to_s)
+  rescue LoadError
+    warn "Please install the launchy gem to open the url automatically."
+    url
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,13 @@ RSpec.configure do |rspec|
   rspec.before :each do
     Trello.reset!
   end
+
+  rspec.around(:each, :silence_warnings) do |example|
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    example.run
+    $VERBOSE = verbose
+  end
 end
 
 module Helpers

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require "launchy"
 
 include Trello
 include Trello::Authorization
@@ -75,6 +76,53 @@ describe Trello do
       it { expect(Trello.auth_policy).to be_a(AuthPolicy) }
       it { expect { Trello.client.get(:member) }.to raise_error(Trello::ConfigurationError) }
     end
+  end
 
+  context "client authorization helpers" do
+    before do
+      allow(Launchy).to receive(:open)
+    end
+
+    it { expect(Trello.public_key_url).to eq("https://trello.com/app-key") }
+    it { expect(Trello.authorize_url(key: "foo")).to match(%r{^https://trello.com/1/authorize}) }
+
+    describe "#open_public_key_url" do
+      it "launches app key endpoint" do
+        expect(Launchy).to receive(:open).with("https://trello.com/app-key")
+
+        Trello.open_public_key_url
+      end
+
+      it "doesn't require launchy", :silence_warnings do
+        allow(Launchy).to receive(:open).and_raise(LoadError)
+
+        expect { Trello.open_public_key_url }.to_not raise_error(LoadError)
+      end
+    end
+
+    describe "#authorize" do
+      it "launches authorize endpoint with configured public key" do
+        app_key = "abcd1234"
+        allow(Trello.configuration).to receive(:developer_public_key).and_return(app_key)
+        authorize_url = "https://trello.com/1/authorize?expiration=never&key=#{app_key}&name=Ruby%20Trello&response_type=token&scope=read%2Cwrite%2Caccount"
+        expect(Launchy).to receive(:open).with(authorize_url)
+
+        Trello.open_authorization_url
+      end
+
+      it "launches authorize endpoint with given public key" do
+        app_key = "wxyz6789"
+        authorize_url = "https://trello.com/1/authorize?expiration=never&key=#{app_key}&name=Ruby%20Trello&response_type=token&scope=read%2Cwrite%2Caccount"
+        expect(Launchy).to receive(:open).with(authorize_url)
+
+        Trello.open_authorization_url(key: "wxyz6789")
+      end
+
+      it "raises an error if key not configured" do
+        expect(Launchy).to_not receive(:open)
+
+        expect { Trello.open_authorization_url }.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "launchy"
+require 'launchy'
 
 include Trello
 include Trello::Authorization
@@ -78,31 +78,31 @@ describe Trello do
     end
   end
 
-  context "client authorization helpers" do
+  context 'client authorization helpers' do
     before do
       allow(Launchy).to receive(:open)
     end
 
-    it { expect(Trello.public_key_url).to eq("https://trello.com/app-key") }
-    it { expect(Trello.authorize_url(key: "foo")).to match(%r{^https://trello.com/1/authorize}) }
+    it { expect(Trello.public_key_url).to eq('https://trello.com/app-key') }
+    it { expect(Trello.authorize_url(key: 'foo')).to match(%r{^https://trello.com/1/authorize}) }
 
-    describe ".open_public_key_url" do
-      it "launches app key endpoint" do
-        expect(Launchy).to receive(:open).with("https://trello.com/app-key")
+    describe '.open_public_key_url' do
+      it 'launches app key endpoint' do
+        expect(Launchy).to receive(:open).with('https://trello.com/app-key')
 
         Trello.open_public_key_url
       end
 
-      it "doesn't require launchy", :silence_warnings do
+      it 'rescues LoadError', :silence_warnings do
         allow(Launchy).to receive(:open).and_raise(LoadError)
 
         expect { Trello.open_public_key_url }.to_not raise_error(LoadError)
       end
     end
 
-    describe ".open_authorization_url" do
-      it "launches authorize endpoint with configured public key" do
-        app_key = "abcd1234"
+    describe '.open_authorization_url' do
+      it 'launches authorize endpoint with configured public key' do
+        app_key = 'abcd1234'
         allow(Trello.configuration).to receive(:developer_public_key).and_return(app_key)
         authorize_url = "https://trello.com/1/authorize?expiration=never&key=#{app_key}&name=Ruby%20Trello&response_type=token&scope=read%2Cwrite%2Caccount"
         expect(Launchy).to receive(:open).with(authorize_url)
@@ -110,15 +110,15 @@ describe Trello do
         Trello.open_authorization_url
       end
 
-      it "launches authorize endpoint with given public key" do
-        app_key = "wxyz6789"
+      it 'launches authorize endpoint with given public key' do
+        app_key = 'wxyz6789'
         authorize_url = "https://trello.com/1/authorize?expiration=never&key=#{app_key}&name=Ruby%20Trello&response_type=token&scope=read%2Cwrite%2Caccount"
         expect(Launchy).to receive(:open).with(authorize_url)
 
-        Trello.open_authorization_url(key: "wxyz6789")
+        Trello.open_authorization_url(key: 'wxyz6789')
       end
 
-      it "raises an error if key not configured" do
+      it 'raises an error if key not configured' do
         expect(Launchy).to_not receive(:open)
 
         expect { Trello.open_authorization_url }.to raise_error(ArgumentError)

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -86,7 +86,7 @@ describe Trello do
     it { expect(Trello.public_key_url).to eq("https://trello.com/app-key") }
     it { expect(Trello.authorize_url(key: "foo")).to match(%r{^https://trello.com/1/authorize}) }
 
-    describe "#open_public_key_url" do
+    describe ".open_public_key_url" do
       it "launches app key endpoint" do
         expect(Launchy).to receive(:open).with("https://trello.com/app-key")
 
@@ -100,7 +100,7 @@ describe Trello do
       end
     end
 
-    describe "#authorize" do
+    describe ".open_authorization_url" do
       it "launches authorize endpoint with configured public key" do
         app_key = "abcd1234"
         allow(Trello.configuration).to receive(:developer_public_key).and_return(app_key)


### PR DESCRIPTION
This PR is intended to make it easier for new users of this gem to get up and running with basic authorization. The existing README instructions are now codified, allowing developers to issue a few commands on console to grab the public key and member token:

```ruby
irb> require 'trello'
irb> Trello.open_public_key_url                         # copy your public key
irb> Trello.open_authorization_url key: 'yourpublickey' # copy your member token
```

I've done something similar for [my Trello client gem](https://github.com/rossta/tacokit.rb#authentication) and thought it would be useful here as well.