### PR TITLE
Allow scope to be passed to Trello.authorize_url

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -128,7 +128,7 @@ module Trello
     params[:key] ||= configuration.developer_public_key or
       raise ArgumentError, 'Please configure your Trello public key'
     params[:name] ||= 'Ruby Trello'
-    params[:scope] = 'read,write,account'
+    params[:scope] ||= 'read,write,account'
     params[:expiration] ||= 'never'
     params[:response_type] ||= 'token'
     uri = Addressable::URI.parse 'https://trello.com/1/authorize'

--- a/spec/trello_spec.rb
+++ b/spec/trello_spec.rb
@@ -86,6 +86,12 @@ describe Trello do
     it { expect(Trello.public_key_url).to eq('https://trello.com/app-key') }
     it { expect(Trello.authorize_url(key: 'foo')).to match(%r{^https://trello.com/1/authorize}) }
 
+    describe '.authorize_url' do
+      it 'allows the scope to be set' do
+        expect(Trello.authorize_url(key: 'foo', scope: 'read')).to match(%r{scope=read$})
+      end
+    end
+
     describe '.open_public_key_url' do
       it 'launches app key endpoint' do
         expect(Launchy).to receive(:open).with('https://trello.com/app-key')


### PR DESCRIPTION
`:scope` is a documented option of `Trello.authorize_url`, but it is ignored and replaced with the default "read,write,account". This change uses the scope provided in the options, but defaults to "read,write,account".