### PR TITLE
Adds card copying.

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -35,13 +35,18 @@ module Trello
   #   @return [Hash]
   # @!attribute [r] card_members
   #   @return [Object]
+  # @!attribute [rw] source_card_id
+  #   @return [String] A 24-character hex string
+  # @!attribute [rw] source_card_properties
+  #   @return [Array<String>] Array of strings
+
   class Card < BasicData
     register_attributes :id, :short_id, :name, :desc, :due, :closed, :url, :short_url,
       :board_id, :member_ids, :list_id, :pos, :last_activity_date, :card_labels,
-      :cover_image_id, :badges, :card_members,
+      :cover_image_id, :badges, :card_members, :source_card_id, :source_card_properties,
       readonly: [ :id, :short_id, :url, :short_url, :last_activity_date, :badges, :card_members ]
     validates_presence_of :id, :name, :list_id
-    validates_length_of   :name,        in: 1..16384
+    validates_length_of   :name, in: 1..16384
     validates_length_of   :desc, in: 0..16384
 
     include HasActions
@@ -63,7 +68,9 @@ module Trello
       last_activity_date: 'dateLastActivity',
       card_labels: 'labels',
       badges: 'badges',
-      card_members: 'members'
+      card_members: 'members',
+      source_card_id: "idCardSource",
+      source_card_properties: "keepFromSource"
     }
 
     class << self
@@ -91,6 +98,11 @@ module Trello
       # @option options [Date] :due A date, or `nil`.
       # @option options [String] :pos A position. `"top"`, `"bottom"`, or a
       #     positive number. Defaults to `"bottom"`.
+      # @option options [String] :source_card_id ID of the card to copy
+      # @option options [String] :source_card_properties A single, or array of,
+      #     string properties to copy from source card.
+      #     `"all"`, `"checklists"`, `"due"`, `"members"`, or `nil`.
+      #     Defaults to `"all"`.
       #
       # @raise [Trello::Error] if the card could not be created.
       #
@@ -103,7 +115,9 @@ module Trello
           'idMembers' => options[:member_ids],
           'labels' => options[:card_labels],
           'due' => options[:due],
-          'pos' => options[:pos]
+          'pos' => options[:pos],
+          'idCardSource' => options[:source_card_id],
+          'keepFromSource' => options.key?(:source_card_properties) ? options[:source_card_properties] : 'all'
         )
       end
     end
@@ -138,27 +152,30 @@ module Trello
     # @option fields [Object] :cover_image_id
     # @option fields [Object] :badges
     # @option fields [Object] :card_members
+    # @option fields [String] :source_card_id
+    # @option fields [Array]  :source_card_properties
     #
     # @return [Trello::Card] self
     def update_fields(fields)
-      attributes[:id]                 = fields[SYMBOL_TO_STRING[:id]]
-      attributes[:short_id]           = fields[SYMBOL_TO_STRING[:short_id]]
-      attributes[:name]               = fields[SYMBOL_TO_STRING[:name]]
-      attributes[:desc]               = fields[SYMBOL_TO_STRING[:desc]]
-      attributes[:due]                = Time.iso8601(fields[SYMBOL_TO_STRING[:due]]) rescue nil
-      attributes[:closed]             = fields[SYMBOL_TO_STRING[:closed]]
-      attributes[:url]                = fields[SYMBOL_TO_STRING[:url]]
-      attributes[:short_url]          = fields[SYMBOL_TO_STRING[:short_url]]
-      attributes[:board_id]           = fields[SYMBOL_TO_STRING[:board_id]]
-      attributes[:member_ids]         = fields[SYMBOL_TO_STRING[:member_ids]]
-      attributes[:list_id]            = fields[SYMBOL_TO_STRING[:list_id]]
-      attributes[:pos]                = fields[SYMBOL_TO_STRING[:pos]]
-      attributes[:card_labels]        = fields[SYMBOL_TO_STRING[:card_labels]]
-      attributes[:last_activity_date] = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil
-      attributes[:cover_image_id]     = fields[SYMBOL_TO_STRING[:cover_image_id]]
-      attributes[:badges]             = fields[SYMBOL_TO_STRING[:badges]]
-      attributes[:card_members]       = fields[SYMBOL_TO_STRING[:card_members]]
-
+      attributes[:id]                     = fields[SYMBOL_TO_STRING[:id]]
+      attributes[:short_id]               = fields[SYMBOL_TO_STRING[:short_id]]
+      attributes[:name]                   = fields[SYMBOL_TO_STRING[:name]]
+      attributes[:desc]                   = fields[SYMBOL_TO_STRING[:desc]]
+      attributes[:due]                    = Time.iso8601(fields[SYMBOL_TO_STRING[:due]]) rescue nil
+      attributes[:closed]                 = fields[SYMBOL_TO_STRING[:closed]]
+      attributes[:url]                    = fields[SYMBOL_TO_STRING[:url]]
+      attributes[:short_url]              = fields[SYMBOL_TO_STRING[:short_url]]
+      attributes[:board_id]               = fields[SYMBOL_TO_STRING[:board_id]]
+      attributes[:member_ids]             = fields[SYMBOL_TO_STRING[:member_ids]]
+      attributes[:list_id]                = fields[SYMBOL_TO_STRING[:list_id]]
+      attributes[:pos]                    = fields[SYMBOL_TO_STRING[:pos]]
+      attributes[:card_labels]            = fields[SYMBOL_TO_STRING[:card_labels]]
+      attributes[:last_activity_date]     = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil
+      attributes[:cover_image_id]         = fields[SYMBOL_TO_STRING[:cover_image_id]]
+      attributes[:badges]                 = fields[SYMBOL_TO_STRING[:badges]]
+      attributes[:card_members]           = fields[SYMBOL_TO_STRING[:card_members]]
+      attributes[:source_card_id]         = fields[SYMBOL_TO_STRING[:source_card_id]]
+      attributes[:source_card_properties] = fields[SYMBOL_TO_STRING[:source_card_properties]]
       self
     end
 
@@ -211,7 +228,9 @@ module Trello
         idMembers: member_ids,
         idLabels: card_labels,
         pos: pos,
-        due: due
+        due: due,
+        idCardSource: source_card_id,
+        keepFromSource: source_card_properties
       })
     end
 

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -84,6 +84,10 @@ module Trello
       end
 
       # Create a new card and save it on Trello.
+      # 
+      # If using source_card_id to duplicate a card, make sure to save
+      # the source card to Trello before calling this method to assure 
+      # the correct data is used in the duplication.
       #
       # @param [Hash] options
       # @option options [String] :name The name of the new card.

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -63,7 +63,7 @@ module Trello
         result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
 
         expected_payload = {name: "Test Card", desc: nil, idList: "abcdef123456789123456789",
-                            idMembers: nil, idLabels: "abcdef123456789123456789", pos: nil, due: nil}
+                            idMembers: nil, idLabels: "abcdef123456789123456789", pos: nil, due: nil, idCardSource: nil, keepFromSource: 'all'}
 
         expect(client)
           .to receive(:post)
@@ -74,6 +74,69 @@ module Trello
 
         expect(card).to be_a Card
       end
+
+      it 'creates a duplicate card with all source properties and saves it on Trello', refactor: true do
+        payload = {
+          source_card_id: cards_details.first['id']
+        }
+
+        result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
+
+        expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: 'all'}
+
+        expect(client)
+          .to receive(:post)
+          .with("/cards", expected_payload)
+          .and_return result
+
+        card = Card.create(cards_details.first.merge(payload.merge(list_id: lists_details.first['id'])))
+
+        expect(card).to be_a Card
+      end
+      
+      it 'creates a duplicate card with source due date and checklists and saves it on Trello', refactor: true do
+        payload = {
+          source_card_id: cards_details.first['id'],
+          source_card_properties: ['due','checklists']
+        }
+
+        result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
+
+        expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: ['due','checklists']}
+
+        expect(client)
+          .to receive(:post)
+          .with("/cards", expected_payload)
+          .and_return result
+
+        card = Card.create(cards_details.first.merge(payload.merge(list_id: lists_details.first['id'])))
+
+        expect(card).to be_a Card
+      end
+
+      it 'creates a duplicate card with no source properties and saves it on Trello', refactor: true do
+        payload = {
+          source_card_id: cards_details.first['id'],
+          source_card_properties: nil
+        }
+
+        result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
+
+        expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: nil}
+
+        expect(client)
+          .to receive(:post)
+          .with("/cards", expected_payload)
+          .and_return result
+
+        card = Card.create(cards_details.first.merge(payload.merge(list_id: lists_details.first['id'])))
+
+        expect(card).to be_a Card
+      end
+
     end
 
     context "updating" do


### PR DESCRIPTION
## Adds the ability to copy cards.
Includes params for including or excluding associated card properties, such as due dates, checklists, and members. The default behavior is to copy everything as per [Trello API docs](https://developers.trello.com/advanced-reference/card#post-1-cards). Note that the duplication takes place via an API call and not locally as class instances, so the source card should be saved to Trello before copying to assure that it's current data will be used when duplicated.

### Examples:
Copy the source card with all attributes and return the duplicated card:
`Card.create(list_id: list.id, source_card_id: source_card.id)` 

Copy the source card with assigned members and checklists only (no due date) and return the duplicated card:
`Card.create(list_id: list.id, source_card_id: source_card.id, source_card_properties: ["members"',"checklists"])` 

Copy the source card with no assigned properties and return the duplicated card:
`Card.create(list_id: list.id, source_card_id: source_card.id, source_card_properties: nil)` 
