### PR TITLE
Avoid type checking when adding attachments to a card

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -360,7 +360,8 @@ module Trello
 
     # Add an attachment to this card
     def add_attachment(attachment, name='')
-      if attachment.is_a? File
+      # Is it a file object or a string (url)?
+      if attachment.respond_to?(:path) && attachment.respond_to?(:read)
         client.post("/cards/#{id}/attachments", {
             file: attachment,
             name: name


### PR DESCRIPTION
I have a Rails app with an html form, this form has a file input wich uploads the file and Rails handles it to me as an instance of  `ActionDispatch::Http::UploadedFile`.

This object has the necessary methods for the [rest-client gem](https://github.com/rest-client/rest-client/blob/30ef4d39cac74ecffc8cd171f69dc1537ea0aef1/lib/restclient/payload.rb#L41) (the gem that ruby-trello uses to execute the requests) to detect and handle it as a file, so I should be able to pass it directly to `Trello::Card#add_attachment`, without converting it to an instance of `File` first.

Unfortunately, `Trello::Card#add_attachment` instead of checking if the received object responds to the methods that will be called (in this case they're actually called in the [rest-client gem](https://github.com/rest-client/rest-client/blob/30ef4d39cac74ecffc8cd171f69dc1537ea0aef1/lib/restclient/payload.rb#L156-L169)) ([duck typing](https://www.practicingruby.com/articles/duck-typing-in-practice-1), as encouraged by the ruby community), [it checks](https://github.com/jeremytregunna/ruby-trello/blob/1e61b9351dce97f11731b0f12c6e45b89efc47f9/lib/trello/card.rb#L363) if the object is an instance of `File` (type checking, as discouraged by the ruby community), so if I pass my  `ActionDispatch::Http::UploadedFile` instance it won't work, even though it could. :disappointed: 

So I have to resort to this kind of thing in my class:
```ruby
def file=(file)
  # About the two to_io weirdness:
  # One to convert from ActionDispatch::Http::UploadedFile to Tempfile
  # The other to convert from Tempfile to File
  # See why: https://goo.gl/HIAr5i
  @file =
    if file.is_a? ActionDispatch::Http::UploadedFile
      @name = file.original_filename
      file.to_io.to_io
    else
      file
    end
end
```
So what I did in the PR is instead of type checking, I use duck typing, and do the [same check they do in the rest-client gem](https://github.com/rest-client/rest-client/blob/30ef4d39cac74ecffc8cd171f69dc1537ea0aef1/lib/restclient/payload.rb#L41), so now it still works with `File` instances, but also works with any object that responds to `#read` and `#path`.

Aaaand, since `ActionDispatch::Http::UploadedFile` responds to `#original_filename`, [the rest-client gem will take advantage of that to set the file name header](https://github.com/rest-client/rest-client/blob/30ef4d39cac74ecffc8cd171f69dc1537ea0aef1/lib/restclient/payload.rb#L160).

I didn't feel the need for new tests since the current ones cover this and still pass, but I can write them if you guys would prefer.