### PR TITLE
Updating gemspec: oauth >= 0.4.5

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2.0'
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json'
-  s.add_dependency 'oauth',       '~> 0.4.5'
+  s.add_dependency 'oauth',       '>= 0.4.5'
   s.add_dependency 'rest-client', '~> 1.8.0'
 end


### PR DESCRIPTION
Updating oauth gem requirement to allow `0.4.5` or greater (current as of this PR is `0.5.1`)

* Needed this because another gem had updated their gem requirements to use `oauth ~> 0.5.0`
* CLA Signed