### PR TITLE
Add checklist method to update item state

### DIFF
--- a/lib/trello/checklist.rb
+++ b/lib/trello/checklist.rb
@@ -107,6 +107,14 @@ module Trello
       client.post("/checklists/#{id}/checkItems", {name: name, checked: checked, pos: position})
     end
 
+    # Update a checklist item's state, e.g.: "complete" or "incomplete"
+    def update_item_state(item_id, state)
+      client.put(
+        "/cards/#{card_id}/checklist/#{id}/checkItem/#{item_id}/state",
+        value: state,
+      )
+    end
+
     # Delete a checklist item
     def delete_checklist_item(item_id)
       client.delete("/checklists/#{id}/checkItems/#{item_id}")
@@ -119,7 +127,7 @@ module Trello
 
     # Copy a checklist (i.e., same attributes, items, etc.)
     def copy
-      checklist_copy = self.class.create(name: self.name, board_id: self.board_id)
+      checklist_copy = self.class.create(name: self.name, board_id: self.board_id, card_id: self.card_id)
       copy_items_to(checklist_copy)
       return checklist_copy
     end

--- a/lib/trello/item.rb
+++ b/lib/trello/item.rb
@@ -20,11 +20,13 @@ module Trello
     # Supply a hash of string keyed data retrieved from the Trello API representing
     # an item.
     def update_fields(fields)
-      attributes[:id]    = fields['id']
-      attributes[:name]  = fields['name']
-      attributes[:type]  = fields['type']
-      attributes[:state] = fields['state']
-      attributes[:pos]   = fields['pos']
+      attributes[:id]           = fields['id']
+      attributes[:card_id]      = fields['idCard']
+      attributes[:checklist_id] = fields['idChecklist']
+      attributes[:name]         = fields['name']
+      attributes[:type]         = fields['type']
+      attributes[:state]        = fields['state']
+      attributes[:pos]          = fields['pos']
       self
     end
 

--- a/spec/checklist_spec.rb
+++ b/spec/checklist_spec.rb
@@ -139,6 +139,17 @@ module Trello
 
         checklist.add_item(expected_item_name, expected_checked, expected_pos)
       end
+
+      it "updates an item's state" do
+        expected_item_id = "1234"
+        expected_state = "incomplete"
+        expected_resource =
+          "/cards/abccardid/checklist/abcdef123456789123456789" \
+          "/checkItem/#{expected_item_id}/state"
+        payload = { value: expected_state }
+        expect(client).to receive(:put).once.with(expected_resource, payload)
+        checklist.update_item_state(expected_item_id, expected_state)
+      end
     end
 
     context "board" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,7 @@ module Helpers
       'position'   => 16384,
       'url'        => 'https://trello.com/blah/blah',
       'idBoard'    => 'abcdef123456789123456789',
+      'idCard'     => 'abccardid',
       'idList'     => 'abcdef123456789123456789',
       'idMembers'  => ['abcdef123456789123456789'],
       'checkItems' => { 'id' => 'ghijk987654321' }


### PR DESCRIPTION
Adding `idCard` to the test data caused other tests to fail around
`Checklist#copy`. It looked to me like it was missing the `cardId`
parameter in the implementation, so I added it there to fix the specs.