### PR TITLE
Allow authenticated user to vote/remove vote on card, add idMembersVoted to card

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -219,6 +219,16 @@ module Trello
       MultiAssociation.new(self, members).proxy
     end
 
+    # Returns a list of members who have upvoted this card
+    # NOTE: this fetches a list each time it's called to avoid case where
+    # card is voted (or vote is removed) after card is fetched. Optimizing
+    # accuracy over network performance
+    #
+    # @return [Array<Trello::Member>]
+    def voters
+      Member.from_response client.get("/cards/#{id}/membersVoted")
+    end
+
     # Saves a record.
     #
     # @raise [Trello::Error] if the card could not be saved

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -358,7 +358,7 @@ module Trello
     def upvote
       begin
         client.post("/cards/#{id}/membersVoted", {
-          value: get_authenticated_user_id
+          value: me.id
         })
       rescue Trello::Error => e
         fail e unless e.message =~ /has already voted/i
@@ -370,20 +370,12 @@ module Trello
     # Recind upvote. Noop if authenticated user hasn't previously voted
     def remove_upvote
       begin
-        client.delete("/cards/#{id}/membersVoted/#{get_authenticated_user_id}")
+        client.delete("/cards/#{id}/membersVoted/#{me.id}")
       rescue Trello::Error => e
         fail e unless e.message =~ /has not voted/i
       end
 
       self
-    end
-
-    # FIXME: this doesn't belong here
-    # Is there a possibility of an application (not a user) that can be
-    # authenticated?
-    private def get_authenticated_user_id
-      mem = Member.from_response client.get('/members/me')
-      mem && mem.id
     end
 
     # Add a label
@@ -439,6 +431,12 @@ module Trello
     # Retrieve a list of comments
     def comments
       comments = Comment.from_response client.get("/cards/#{id}/actions", filter: "commentCard")
+    end
+
+    private
+
+    def me
+      @me ||= Member.find(:me)
     end
   end
 end

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -344,6 +344,24 @@ module Trello
       client.delete("/cards/#{id}/members/#{member.id}")
     end
 
+    # Current authenticated user upvotes a card
+    def upvote
+      client.post("/cards/#{id}/membersVoted", {
+        value: get_authenticated_user_id
+      })
+    end
+
+    # Recind upvote. Noop if authenticated user hasn't previously voted
+    def remove_upvote
+      client.delete("/cards/#{id}/membersVoted/#{get_authenticated_user_id}")
+    end
+
+    # FIXME: this doesn't belong here
+    private def get_authenticated_user_id
+      mem = Member.from_response client.get('/members/me')
+      mem && mem.id
+    end
+
     # Add a label
     def add_label(label)
       unless label.valid?

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -447,7 +447,27 @@ module Trello
 
         card.remove_upvote
       end
+
+      it 'returns members that have voted for the card' do
+        no_voters = JSON.generate([])
+        expect(client)
+          .to receive(:get)
+          .with("/cards/#{card.id}/membersVoted")
+          .and_return(no_voters)
+
+        card.voters
+
+
+        voters = JSON.generate([user_details])
+        expect(client)
+          .to receive(:get)
+          .with("/cards/#{card.id}/membersVoted")
+          .and_return(voters)
+
+        expect(card.voters.first).to be_kind_of Trello::Member
+      end
     end
+
 
     context "comments" do
       it "posts a comment" do

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -402,13 +402,13 @@ module Trello
       end
     end
 
-    context "votes" do
+    context "add/remove votes" do
       let(:authenticated_member) { double(id: '4ee7df3ce582acdec80000b2') }
 
       before do
         allow(card)
-          .to receive(:get_authenticated_user_id)
-          .and_return(authenticated_member.id)
+          .to receive(:me)
+          .and_return(authenticated_member)
       end
 
       it 'upvotes a card with the currently authenticated member' do
@@ -448,6 +448,9 @@ module Trello
         card.remove_upvote
       end
 
+    end
+
+    context "return all voters" do
       it 'returns members that have voted for the card' do
         no_voters = JSON.generate([])
         expect(client)

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -94,7 +94,7 @@ module Trello
 
         expect(card).to be_a Card
       end
-      
+
       it 'creates a duplicate card with source due date and checklists and saves it on Trello', refactor: true do
         payload = {
           source_card_id: cards_details.first['id'],
@@ -399,6 +399,34 @@ module Trello
           .with("/cards/abcdef123456789123456789/members/#{existing_member.id}")
 
         card.remove_member(existing_member)
+      end
+    end
+
+    context "votes" do
+      let(:authenticated_member) { double(id: '4ee7df3ce582acdec80000b2') }
+
+      before do
+        allow(card)
+          .to receive(:get_authenticated_user_id)
+          .and_return(authenticated_member.id)
+      end
+
+      it 'upvotes a card with the currently authenticated member' do
+        expect(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/membersVoted", {
+            value: authenticated_member.id
+          })
+
+        card.upvote
+      end
+
+      it 'removes an upvote from a card' do
+        expect(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/membersVoted/#{authenticated_member.id}")
+
+        card.remove_upvote
       end
     end
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -421,10 +421,29 @@ module Trello
         card.upvote
       end
 
+      it 'returns the card even if the user has already upvoted' do
+        expect(client)
+          .to receive(:post)
+          .with("/cards/abcdef123456789123456789/membersVoted", {
+            value: authenticated_member.id
+          })
+          .and_raise(Trello::Error, 'member has already voted')
+        expect(card.upvote).to be_kind_of Trello::Card
+      end
+
       it 'removes an upvote from a card' do
         expect(client)
           .to receive(:delete)
           .with("/cards/abcdef123456789123456789/membersVoted/#{authenticated_member.id}")
+
+        card.remove_upvote
+      end
+
+      it 'returns card after remove_upvote even if the user has not previously upvoted it' do
+        expect(client)
+          .to receive(:delete)
+          .with("/cards/abcdef123456789123456789/membersVoted/#{authenticated_member.id}")
+          .and_raise(Trello::Error, 'member has not voted on the card')
 
         card.remove_upvote
       end


### PR DESCRIPTION
## What

See #202 for more details. This PR adds support for adding/removing votes to a card. It also adds idMembersVoted to card attributes (though this last part is WIP)

## How to test

Authenticate and execute the following code:
```ruby
card = Trello::Card.find('id-of-card')
card.upvote
card.remove_upvote

# now do it and be obnoxious
card.upvote
card.upvote
card.upvote

card.remove_upvote
card.remove_upvote
```

## Note

I'll be able to add `idMembersVoted` to the PR tomorrow (2016-08-04)