### PR TITLE
Adding a created_at method

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -398,5 +398,10 @@ module Trello
     def comments
       comments = Comment.from_response client.get("/cards/#{id}/actions", filter: "commentCard")
     end
+
+    # Find the creation date
+    def created_at
+      Time.at(id[0..7].to_i(16)) rescue nil
+    end
   end
 end

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -434,12 +434,6 @@ module Trello
     end
 
     # Find the creation date
-
-    # id                          => 4d5ea62fd76aa1136000000c
-    # id[0..7]                    => 4d5ea62f
-    # id[0..7].to_i(16)           => 1298048559
-    # Time.at(id[0..7].to_i(16))  => 2011-02-18 18:02:39 +0100
-
     def created_at
       @created_at ||= Time.at(id[0..7].to_i(16)) rescue nil
     end

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{ruby-trello}
-  s.version           = "1.5.0"
+  s.version           = "1.5.1"
   s.platform          = Gem::Platform::RUBY
   s.license           = 'MIT'
 

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{ruby-trello}
-  s.version           = "1.5.1"
+  s.version           = "1.5.0"
   s.platform          = Gem::Platform::RUBY
   s.license           = 'MIT'
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -223,7 +223,7 @@ module Trello
 
 
       it "gets its creation date" do
-        expect(card.created_at).to eq(Time.at(card.id[0..7].to_i(16)))
+        expect(card.created_at).to be_kind_of Time
       end
 
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -220,6 +220,11 @@ module Trello
       it "gets its pos" do
         expect(card.pos).to_not be_nil
       end
+
+      it "gets its creation date" do
+        expect(card.created_at).to_not be_nil
+      end
+
     end
 
     context "actions" do

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -222,8 +222,12 @@ module Trello
       end
 
 
-      it "gets its creation date" do
+      it 'gets its creation time' do
         expect(card.created_at).to be_kind_of Time
+      end
+
+      it 'get its correct creation time' do
+        expect(card.created_at).to eq(Time.parse('2061-05-04 04:40:18 +0200'))
       end
 
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -223,7 +223,7 @@ module Trello
 
 
       it "gets its creation date" do
-        expect(card.created_at).to_not be_nil
+        expect(card.created_at).to eq(Time.at(card.id[0..7].to_i(16)))
       end
 
     end


### PR DESCRIPTION
Hi

Since I needed the card creation time. Instead of a dirty override to add the method and maybe some other pepole need this method I added it. Even if it's not in the JSON you can find it in the ID.
(http://help.trello.com/article/759-getting-the-time-a-card-or-board-was-created) 

I only added it on the Card object this method should work with the Board object.


