### PR TITLE
added dueComplete flag and associated test

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -43,7 +43,7 @@ module Trello
   #   @return [Array<String>] Array of strings
 
   class Card < BasicData
-    register_attributes :id, :short_id, :name, :desc, :due, :closed, :url, :short_url,
+    register_attributes :id, :short_id, :name, :desc, :due, :due_complete, :closed, :url, :short_url,
       :board_id, :member_ids, :list_id, :pos, :last_activity_date, :labels, :card_labels,
       :cover_image_id, :badges, :card_members, :source_card_id, :source_card_properties,
       readonly: [ :id, :short_id, :url, :short_url, :last_activity_date, :badges, :card_members ]
@@ -59,6 +59,7 @@ module Trello
       name: 'name',
       desc: 'desc',
       due: 'due',
+      due_complete: 'dueComplete',
       closed: 'closed',
       url: 'url',
       short_url: 'shortUrl',
@@ -122,6 +123,7 @@ module Trello
           'idMembers' => options[:member_ids],
           'idLabels' => options[:card_labels],
           'due' => options[:due],
+          'due_complete' => options[:due_complete] || false,
           'pos' => options[:pos],
           'idCardSource' => options[:source_card_id],
           'keepFromSource' => options.key?(:source_card_properties) ? options[:source_card_properties] : 'all'
@@ -146,6 +148,7 @@ module Trello
     # @option fields [String] :desc A string with a length from 0 to
     #     16384.
     # @option fields [Date] :due A date, or `nil`.
+    # @option fields [Boolean] :due_complete
     # @option fields [Boolean] :closed
     # @option fields [String] :url
     # @option fields [String] :short_url
@@ -171,7 +174,8 @@ module Trello
       attributes[:name]                   = fields[SYMBOL_TO_STRING[:name]] || fields[:name]
       attributes[:desc]                   = fields[SYMBOL_TO_STRING[:desc]] || fields[:desc]
       attributes[:due]                    = Time.iso8601(fields[SYMBOL_TO_STRING[:due]]) rescue nil
-      attributes[:due]                  ||= fields[:due]
+      attributes[:due]                    ||= fields[:due]
+      attributes[:due_complete]           = fields[SYMBOL_TO_STRING[:due_complete]] || false
       attributes[:closed]                 = fields[SYMBOL_TO_STRING[:closed]]
       attributes[:url]                    = fields[SYMBOL_TO_STRING[:url]]
       attributes[:short_url]              = fields[SYMBOL_TO_STRING[:short_url]]
@@ -248,6 +252,7 @@ module Trello
         idLabels: card_labels,
         pos: pos,
         due: due,
+        dueComplete: due_complete,
         idCardSource: source_card_id,
         keepFromSource: source_card_properties
       })

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{ruby-trello}
-  s.version           = "1.5.1"
+  s.version           = "1.5.2"
   s.platform          = Gem::Platform::RUBY
   s.license           = 'MIT'
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -99,7 +99,7 @@ module Trello
         result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
 
         expected_payload = {name: "Test Card", desc: nil, idList: "abcdef123456789123456789",
-                            idMembers: nil, idLabels: "abcdef123456789123456789", pos: nil, due: nil, idCardSource: nil, keepFromSource: 'all'}
+                            idMembers: nil, idLabels: "abcdef123456789123456789", pos: nil, due: nil, dueComplete: false, idCardSource: nil, keepFromSource: 'all'}
 
         expect(client)
           .to receive(:post)
@@ -119,7 +119,7 @@ module Trello
         result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
 
         expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
-                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: 'all'}
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, dueComplete: false, idCardSource: cards_details.first['id'], keepFromSource: 'all'}
 
         expect(client)
           .to receive(:post)
@@ -140,7 +140,7 @@ module Trello
         result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
 
         expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
-                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: ['due', 'checklists']}
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, dueComplete: false, idCardSource: cards_details.first['id'], keepFromSource: ['due', 'checklists']}
 
         expect(client)
           .to receive(:post)
@@ -161,7 +161,7 @@ module Trello
         result = JSON.generate(cards_details.first.merge(payload.merge(idList: lists_details.first['id'])))
 
         expected_payload = {name: nil, desc: nil, idList: "abcdef123456789123456789",
-                            idMembers: nil, idLabels: nil, pos: nil, due: nil, idCardSource: cards_details.first['id'], keepFromSource: nil}
+                            idMembers: nil, idLabels: nil, pos: nil, due: nil, dueComplete: false, idCardSource: cards_details.first['id'], keepFromSource: nil}
 
         expect(client)
           .to receive(:post)
@@ -683,6 +683,20 @@ module Trello
           .with("/cards/abcdef123456789123456789", payload)
 
         card.close!
+      end
+    end
+
+    describe "can mark due_complete" do
+      it "updates the due completed attribute to true" do
+        card.due = Time.now
+        card.save
+
+        expect(card.due).to_not be_nil
+
+        card.due_complete = true
+        card.save 
+
+        expect(card.due_complete).to_be true
       end
     end
   end


### PR DESCRIPTION
dueComplete is an optional flag on [PUT /1/cards/[card id or shortlink]](https://developers.trello.com/advanced-reference/card#put-1-cards-card-id-or-shortlink) which checks off the due date

![](https://cloud.githubusercontent.com/assets/1323524/20773452/795692fa-b717-11e6-8b17-c9cc57849d7f.gif)
