### PR TITLE
enable use of newer rest-client version

### DIFF
--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json'
   s.add_dependency 'oauth',       '>= 0.4.5'
-  s.add_dependency 'rest-client', '~> 1.8.0'
+  s.add_dependency 'rest-client', '>= 1.8.0'
 end


### PR DESCRIPTION
used rest-client 1.8.0 till now which misses some features of 2.0.0 but
seems to be compatible with with ruby-trello. Using ``>=`` will enable usage of 2.0.0 but won't block the gem for users of rest-client 1.8.0
Jruby builds fail as they do on current master, rest should be fine