### PR TITLE
Features/add plugin support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gemspec
 group :development, :spec do
   gem 'jruby-openssl', :platforms => :jruby
   gem 'rake'
-  gem 'rspec', '~> 3.3.0'
+  gem 'rspec', '~> 3.5.0'
   gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
   gem 'webmock'
   gem 'launchy'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -59,6 +59,7 @@ module Trello
   autoload :MultiAssociation,  'trello/multi_association'
   autoload :Notification,      'trello/notification'
   autoload :Organization,      'trello/organization'
+  autoload :Plugin,            'trello/plugin'
   autoload :Request,           'trello/net'
   autoload :TInternet,         'trello/net'
   autoload :Token,             'trello/token'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -59,7 +59,7 @@ module Trello
   autoload :MultiAssociation,  'trello/multi_association'
   autoload :Notification,      'trello/notification'
   autoload :Organization,      'trello/organization'
-  autoload :Plugin,            'trello/plugin'
+  autoload :PluginDatum,       'trello/plugin_datum'
   autoload :Request,           'trello/net'
   autoload :TInternet,         'trello/net'
   autoload :Token,             'trello/token'

--- a/lib/trello/basic_data.rb
+++ b/lib/trello/basic_data.rb
@@ -90,8 +90,10 @@ module Trello
           options   = opts.dup
           resource  = options.delete(:in)  || self.class.to_s.split("::").last.downcase.pluralize
           klass     = options.delete(:via) || Trello.const_get(name.to_s.singularize.camelize)
+          path = options.delete(:path) || name
           params    = options.merge(args[0] || {})
-          resources = client.find_many(klass, "/#{resource}/#{id}/#{name}", params)
+
+          resources = client.find_many(klass, "/#{resource}/#{id}/#{path}", params)
           MultiAssociation.new(self, resources).proxy
         end
       end

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -203,7 +203,7 @@ module Trello
     many :checklists, filter: :all
 
     # Returns a list of plugins associated with the card
-    many :plugins
+    many :plugin_data, path: "pluginData"
 
     def check_item_states
       states = CheckItemState.from_response client.get("/cards/#{self.id}/checkItemStates")

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -202,6 +202,9 @@ module Trello
     #    :filter => [ :none, :all ] # default :all
     many :checklists, filter: :all
 
+    # Returns a list of plugins associated with the card
+    many :plugins
+
     def check_item_states
       states = CheckItemState.from_response client.get("/cards/#{self.id}/checkItemStates")
       MultiAssociation.new(self, states).proxy

--- a/lib/trello/plugin.rb
+++ b/lib/trello/plugin.rb
@@ -24,7 +24,7 @@ module Trello
       attributes[:id]        = fields['id']
       attributes[:idPlugin]  = fields['idPlugin']
       attributes[:scope]     = fields['scope']
-      attributes[:value]     = fields['value']
+      attributes[:value]     = JSON.parse fields['value']
       attributes[:idModel]   = fields['idModel']
       attributes[:access]    = fields['access']
       self

--- a/lib/trello/plugin.rb
+++ b/lib/trello/plugin.rb
@@ -1,0 +1,33 @@
+module Trello
+  # A file or url that is linked to a Trello card
+  #
+  # @!attribute id
+  #   @return [String]
+  # @!attribute idPlugin
+  #   @return [String]
+  # @!attribute scope
+  #   @return [String]
+  # @!attribute idModel
+  #   @return [String]
+  # @!attribute value
+  #   @return [String]
+  # @!attribute access
+  #   @return [String]
+    class Plugin < BasicData
+    # Update the fields of a plugin.
+    register_attributes :id, :idPlugin, :scope, :idModel, :value, :access
+
+
+    # Supply a hash of stringkeyed data retrieved from the Trello API representing
+    # an attachment.
+    def update_fields(fields)
+      attributes[:id]        = fields['id']
+      attributes[:idPlugin]  = fields['idPlugin']
+      attributes[:scope]     = fields['scope']
+      attributes[:value]     = fields['value']
+      attributes[:idModel]   = fields['idModel']
+      attributes[:access]    = fields['access']
+      self
+    end
+  end
+end

--- a/lib/trello/plugin_datum.rb
+++ b/lib/trello/plugin_datum.rb
@@ -30,4 +30,5 @@ module Trello
       self
     end
   end
+
 end

--- a/lib/trello/plugin_datum.rb
+++ b/lib/trello/plugin_datum.rb
@@ -13,7 +13,7 @@ module Trello
   #   @return [String]
   # @!attribute access
   #   @return [String]
-    class Plugin < BasicData
+    class PluginDatum < BasicData
     # Update the fields of a plugin.
     register_attributes :id, :idPlugin, :scope, :idModel, :value, :access
 

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -597,6 +597,40 @@ module Trello
       end
     end
 
+    context "plugins" do
+      it "can list the existing plugins with correct fields" do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789", {})
+          .and_return JSON.generate(boards_details.first)
+
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/plugins", {})
+          .and_return plugins_payload
+
+        expect(card.board).to_not be_nil
+        expect(card.plugins).to_not be_nil
+
+        first_plugin = card.plugins.first
+        expect(first_plugin.id).to eq plugins_details[0]["id"]
+        expect(first_plugin.idPlugin).to eq plugins_details[0]["idPlugin"]
+        expect(first_plugin.scope).to eq plugins_details[0]["scope"]
+        expect(first_plugin.idModel).to eq plugins_details[0]["idModel"]
+        expect(first_plugin.value).to eq plugins_details[0]["value"]
+        expect(first_plugin.access).to eq plugins_details[0]["access"]
+
+        second_plugin = card.plugins[1]
+        expect(second_plugin.id).to eq plugins_details[1]["id"]
+        expect(second_plugin.idPlugin).to eq plugins_details[1]["idPlugin"]
+        expect(second_plugin.scope).to eq plugins_details[1]["scope"]
+        expect(second_plugin.idModel).to eq plugins_details[1]["idModel"]
+        expect(second_plugin.value).to eq plugins_details[1]["value"]
+        expect(second_plugin.access).to eq plugins_details[1]["access"]
+
+      end
+    end
+
     context "attachments" do
       it "can add an attachment" do
         f = File.new('spec/list_spec.rb', 'r')

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -606,27 +606,27 @@ module Trello
 
         allow(client)
           .to receive(:get)
-          .with("/cards/abcdef123456789123456789/plugins", {})
-          .and_return plugins_payload
+          .with("/cards/abcdef123456789123456789/pluginData", {})
+          .and_return plugin_data_payload
 
         expect(card.board).to_not be_nil
-        expect(card.plugins).to_not be_nil
+        expect(card.plugin_data).to_not be_nil
 
-        first_plugin = card.plugins.first
-        expect(first_plugin.id).to eq plugins_details[0]["id"]
-        expect(first_plugin.idPlugin).to eq plugins_details[0]["idPlugin"]
-        expect(first_plugin.scope).to eq plugins_details[0]["scope"]
-        expect(first_plugin.idModel).to eq plugins_details[0]["idModel"]
-        expect(first_plugin.value).to eq JSON.parse plugins_details[0]["value"]
-        expect(first_plugin.access).to eq plugins_details[0]["access"]
+        first_plugin = card.plugin_data.first
+        expect(first_plugin.id).to eq plugin_data_details[0]["id"]
+        expect(first_plugin.idPlugin).to eq plugin_data_details[0]["idPlugin"]
+        expect(first_plugin.scope).to eq plugin_data_details[0]["scope"]
+        expect(first_plugin.idModel).to eq plugin_data_details[0]["idModel"]
+        expect(first_plugin.value).to eq JSON.parse plugin_data_details[0]["value"]
+        expect(first_plugin.access).to eq plugin_data_details[0]["access"]
 
-        second_plugin = card.plugins[1]
-        expect(second_plugin.id).to eq plugins_details[1]["id"]
-        expect(second_plugin.idPlugin).to eq plugins_details[1]["idPlugin"]
-        expect(second_plugin.scope).to eq plugins_details[1]["scope"]
-        expect(second_plugin.idModel).to eq plugins_details[1]["idModel"]
-        expect(second_plugin.value).to eq JSON.parse plugins_details[1]["value"]
-        expect(second_plugin.access).to eq plugins_details[1]["access"]
+        second_plugin = card.plugin_data[1]
+        expect(second_plugin.id).to eq plugin_data_details[1]["id"]
+        expect(second_plugin.idPlugin).to eq plugin_data_details[1]["idPlugin"]
+        expect(second_plugin.scope).to eq plugin_data_details[1]["scope"]
+        expect(second_plugin.idModel).to eq plugin_data_details[1]["idModel"]
+        expect(second_plugin.value).to eq JSON.parse plugin_data_details[1]["value"]
+        expect(second_plugin.access).to eq plugin_data_details[1]["access"]
 
       end
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -617,7 +617,7 @@ module Trello
         expect(first_plugin.idPlugin).to eq plugins_details[0]["idPlugin"]
         expect(first_plugin.scope).to eq plugins_details[0]["scope"]
         expect(first_plugin.idModel).to eq plugins_details[0]["idModel"]
-        expect(first_plugin.value).to eq plugins_details[0]["value"]
+        expect(first_plugin.value).to eq JSON.parse plugins_details[0]["value"]
         expect(first_plugin.access).to eq plugins_details[0]["access"]
 
         second_plugin = card.plugins[1]
@@ -625,7 +625,7 @@ module Trello
         expect(second_plugin.idPlugin).to eq plugins_details[1]["idPlugin"]
         expect(second_plugin.scope).to eq plugins_details[1]["scope"]
         expect(second_plugin.idModel).to eq plugins_details[1]["idModel"]
-        expect(second_plugin.value).to eq plugins_details[1]["value"]
+        expect(second_plugin.value).to eq JSON.parse plugins_details[1]["value"]
         expect(second_plugin.access).to eq plugins_details[1]["access"]
 
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -220,7 +220,7 @@ module Helpers
     JSON.generate(attachments_details)
   end
 
-  def plugins_details
+  def plugin_data_details
     [
       {
         "id"=>"abcdef123456789123456779",
@@ -241,8 +241,8 @@ module Helpers
     ]
   end
 
-  def plugins_payload
-    JSON.generate(plugins_details)
+  def plugin_data_payload
+    JSON.generate(plugin_data_details)
   end
 
   def card_payload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -220,6 +220,31 @@ module Helpers
     JSON.generate(attachments_details)
   end
 
+  def plugins_details
+    [
+      {
+        "id"=>"abcdef123456789123456779",
+        "idPlugin"=>"abcdef123456789123456879",
+        "scope"=>"card",
+        "idModel"=>"abcdef123456789123446879",
+        "value"=>"{\"fields\":{\"plugin_key\":\"plugin_value\"}}",
+        "access"=>"shared"
+      },
+      {
+        "id"=>"abcdef123456789123456879",
+        "idPlugin"=>"abcdef123456789123456779",
+        "scope"=>"card",
+        "idModel"=>"abcdef123456789123446579",
+        "value"=>"{\"fields\":{\"plugin_key\":\"plugin_value\"}}",
+        "access"=>"shared"
+      }
+    ]
+  end
+
+  def plugins_payload
+    JSON.generate(plugins_details)
+  end
+
   def card_payload
     JSON.generate(cards_details.first)
   end


### PR DESCRIPTION
/cards/id/PluginData on the API returns the data for plugins that have been attached to the card, for example the custom fields power up

This PR allows that data to be accessed