### PR TITLE
Adding plugin_data to board

### DIFF
--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -156,6 +156,9 @@ module Trello
 
     # Returns a reference to the organization this board belongs to.
     one :organization, path: :organizations, using: :organization_id
+    
+    # Returns a list of plugins associated with the board
+    many :plugin_data, path: "pluginData"
 
     def labels(params = {})
       # Set the limit to as high as possible given there is no pagination in this API.


### PR DESCRIPTION
Hello!
         the gem is awesome, thanks for publish it!
With this simple change, you get de plugin_data for the boards. It gives us usefull information about the name of the custom fields.

https://developers.trello.com/advanced-reference/board#get-1-boards-board-id-pluginData