### PR TITLE
add Card#move_to_list_on_any_board 

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -343,6 +343,16 @@ module Trello
       end
     end
 
+    # Moves this card to the given list no matter which board it is on
+    def move_to_list_on_any_board(list_id)
+      list = List.find(list_id)
+      if board.id == list.board_id
+        move_to_list(list_id)
+      else
+        move_to_board(Board.find(list.board_id), list)
+      end
+    end
+
     # Move this card to the given board (and optional list on this board)
     def move_to_board(new_board, new_list = nil)
       unless board_id == new_board.id

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -399,6 +399,45 @@ module Trello
         card.move_to_board(other_board, other_list)
       end
 
+      it 'can be moved to a list on the same board' do
+        current_board = double(id: 'abcdef123456789123456789')
+        other_list = double(
+          id: '987654321987654321fedcba',
+          board_id: 'abcdef123456789123456789'
+        )
+        allow(List).to receive(:find).with('987654321987654321fedcba').
+          and_return(other_list)
+        allow(card).to receive(:board).and_return(current_board)
+        payload = {value: other_list.id}
+
+        expect(client)
+          .to receive(:put)
+          .with('/cards/abcdef123456789123456789/idList', payload)
+
+        card.move_to_list_on_any_board(other_list.id)
+      end
+
+      it 'can be moved to a list on another board' do
+        current_board = double(id: 'abcdef123456789123456789')
+        other_board = double(id: '987654321987654321fedcba')
+        other_list = double(
+          id: '987654321987654321aalist',
+          board_id: '987654321987654321fedcba'
+        )
+        allow(List).to receive(:find).with('987654321987654321aalist').
+          and_return(other_list)
+        allow(card).to receive(:board).and_return(current_board)
+        allow(Board).to receive(:find).with('987654321987654321fedcba').
+          and_return(other_board)
+        payload = { value: other_board.id, idList: other_list.id }
+
+        expect(client)
+          .to receive(:put)
+          .with('/cards/abcdef123456789123456789/idBoard', payload)
+
+        card.move_to_list_on_any_board(other_list.id)
+      end
+
       it 'should not be moved if new board is identical with old board', focus: true do
         other_board = double(id: 'abcdef123456789123456789')
         expect(client).to_not receive(:put)


### PR DESCRIPTION
Adds an ``move_to_list_on_any_board`` instance method to
``Trello::Card`` which may move the card to the specified list on any
board. It uses either ``move_to_list`` or ``move_to_board`` as the API
does not move the card if you use the wrong call, e.g. it does not
move the card when using ``move_to_board`` with the target list and
the card being on the same board and ``move_to_list`` does not move the
card if the list is on another board.