### PR TITLE
Error status code

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -37,6 +37,7 @@ require 'addressable/uri'
 #
 # Feel free to {peruse and participate in our Trello board}[https://trello.com/board/ruby-trello/4f092b2ee23cb6fe6d1aaabd]. It's completely open to the public.
 module Trello
+  autoload :Error,             'trello/error'
   autoload :Action,            'trello/action'
   autoload :Comment,           'trello/comment'
   autoload :Association,       'trello/association'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -75,9 +75,6 @@ module Trello
   # Version of the Trello API that we use by default.
   API_VERSION = 1
 
-  # Raise this when we hit a Trello error.
-  Error = Class.new(StandardError)
-
   # This specific error is thrown when your access token is invalid. You should get a new one.
   InvalidAccessToken = Class.new(Error)
 

--- a/lib/trello/client.rb
+++ b/lib/trello/client.rb
@@ -96,7 +96,7 @@ module Trello
 
       unless [200, 201].include? response.code
         Trello.logger.error("[#{response.code} #{name.to_s.upcase} #{uri}]: #{response.body}")
-        raise Error, response.body
+        raise Error.new(response.code, response.body)
       end
 
       response.body

--- a/lib/trello/error.rb
+++ b/lib/trello/error.rb
@@ -1,0 +1,12 @@
+module Trello
+  class Error < StandardError
+
+    attr_reader :status
+
+    def initialize(status, message)
+      @status = status
+      super(message)
+    end
+
+  end
+end


### PR DESCRIPTION
Because Trello return a free text field as error body, it makes it difficult to reliably differentiate between `4xx` errors and `5xx` errors. 

This PR adds the HTTP response status code to the `Trello::Error` class as an additional attribute `#status`.