### PR TITLE
Error status code

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -37,6 +37,7 @@ require 'addressable/uri'
 #
 # Feel free to {peruse and participate in our Trello board}[https://trello.com/board/ruby-trello/4f092b2ee23cb6fe6d1aaabd]. It's completely open to the public.
 module Trello
+  autoload :Error,             'trello/error'
   autoload :Action,            'trello/action'
   autoload :Comment,           'trello/comment'
   autoload :Association,       'trello/association'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -75,9 +75,6 @@ module Trello
   # Version of the Trello API that we use by default.
   API_VERSION = 1
 
-  # Raise this when we hit a Trello error.
-  Error = Class.new(StandardError)
-
   # This specific error is thrown when your access token is invalid. You should get a new one.
   InvalidAccessToken = Class.new(Error)
 

--- a/lib/trello/client.rb
+++ b/lib/trello/client.rb
@@ -96,7 +96,7 @@ module Trello
 
       unless [200, 201].include? response.code
         Trello.logger.error("[#{response.code} #{name.to_s.upcase} #{uri}]: #{response.body}")
-        raise Error.new(response.code, response.body)
+        raise Error.new(response.body, response.code)
       end
 
       response.body

--- a/lib/trello/client.rb
+++ b/lib/trello/client.rb
@@ -96,7 +96,7 @@ module Trello
 
       unless [200, 201].include? response.code
         Trello.logger.error("[#{response.code} #{name.to_s.upcase} #{uri}]: #{response.body}")
-        raise Error, response.body
+        raise Error.new(response.code, response.body)
       end
 
       response.body

--- a/lib/trello/error.rb
+++ b/lib/trello/error.rb
@@ -1,10 +1,10 @@
 module Trello
   class Error < StandardError
 
-    attr_reader :status
+    attr_reader :status_code
 
-    def initialize(message, status=nil)
-      @status = status
+    def initialize(message, status_code=nil)
+      @status_code = status_code
       super(message)
     end
 

--- a/lib/trello/error.rb
+++ b/lib/trello/error.rb
@@ -3,7 +3,7 @@ module Trello
 
     attr_reader :status
 
-    def initialize(status, message)
+    def initialize(message, status=nil)
       @status = status
       super(message)
     end

--- a/lib/trello/error.rb
+++ b/lib/trello/error.rb
@@ -1,0 +1,12 @@
+module Trello
+  class Error < StandardError
+
+    attr_reader :status
+
+    def initialize(status, message)
+      @status = status
+      super(message)
+    end
+
+  end
+end

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{ruby-trello}
-  s.version           = "2.0.0"
+  s.version           = "2.0.1"
   s.platform          = Gem::Platform::RUBY
   s.license           = 'MIT'
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -53,7 +53,7 @@ describe Client do
         expect { client.get "/xxx" }.to raise_error do |error|
           expect(error).to be_a(Error)
           expect(error.message).to eq("404 error response")
-          expect(error.status).to eq(404)
+          expect(error.status_code).to eq(404)
         end
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -50,7 +50,11 @@ describe Client do
           .to receive(:try_execute)
           .and_return(response_with_non_200_status)
 
-        expect { client.get "/xxx" }.to raise_error(Error, "404 error response")
+        expect { client.get "/xxx" }.to raise_error do |error|
+          expect(error).to be_a(Error)
+          expect(error.message).to eq("404 error response")
+          expect(error.status).to eq(404)
+        end
       end
     end
   end


### PR DESCRIPTION
Differentiating between `4xx` and `5xx` errors is difficult because Trello doesn't return structured error information. Also `429` (rate limit exceeded) should be handled differently to other `4xx` errors. 

This PR adds the HTTP status code to the `Trello::Error` class as `#status_code` to allow more reliable error handling.