### PR TITLE
Improve equality of BasicData objects

### DIFF
--- a/lib/trello/basic_data.rb
+++ b/lib/trello/basic_data.rb
@@ -125,6 +125,14 @@ module Trello
       self.class == other.class && id == other.id
     end
 
+    # Alias hash equality to equality
+    alias eql? ==
+
+    # Delegate hash key computation to class and id pair
+    def hash
+      [self.class, id].hash
+    end
+
     def client
       @client ||= self.class.client
     end

--- a/lib/trello/basic_data.rb
+++ b/lib/trello/basic_data.rb
@@ -122,7 +122,7 @@ module Trello
 
     # Two objects are equal if their _id_ methods are equal.
     def ==(other)
-      id == other.id
+      self.class == other.class && id == other.id
     end
 
     def client

--- a/spec/basic_data_spec.rb
+++ b/spec/basic_data_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module Trello
+  describe BasicData do
+    describe "equality" do
+      specify "two objects of the same type are equal if their id values are equal" do
+        data_object = Card.new('id' => 'abc123')
+        other_data_object = Card.new('id' => 'abc123')
+
+        expect(data_object).to eq(other_data_object)
+      end
+
+      specify "two object of the samy type are not equal if their id values are different" do
+        data_object = Card.new('id' => 'abc123')
+        other_data_object = Card.new('id' => 'def456')
+
+        expect(data_object).not_to eq(other_data_object)
+      end
+
+      specify "two object of different types are not equal even if their id values are equal" do
+        card = Card.new('id' => 'abc123')
+        list = List.new('id' => 'abc123')
+
+        expect(card.id).to eq(list.id)
+        expect(card).to_not eq(list)
+      end
+    end
+  end
+end

--- a/spec/basic_data_spec.rb
+++ b/spec/basic_data_spec.rb
@@ -25,5 +25,34 @@ module Trello
         expect(card).to_not eq(list)
       end
     end
+
+    describe "hash equality" do
+      specify "two objects of the same type point to the same hash key" do
+        data_object = Card.new('id' => 'abc123')
+        other_data_object = Card.new('id' => 'abc123')
+
+        hash = {data_object => 'one'}
+
+        expect(hash[other_data_object]).to eq('one')
+      end
+
+      specify "two object of the same type with different ids do not point to the same hash key" do
+        data_object = Card.new('id' => 'abc123')
+        other_data_object = Card.new('id' => 'def456')
+
+        hash = {data_object => 'one'}
+
+        expect(hash[other_data_object]).to be_nil
+      end
+
+      specify "two object of different types with same ids do not point to the same hash key" do
+        card = Card.new('id' => 'abc123')
+        list = List.new('id' => 'abc123')
+
+        hash = {card => 'one'}
+
+        expect(hash[list]).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi,

I noticed that grouping cards by list didn't work properly, so I implemented the hash equality in `BasicData`.

While doing that, I noticed a small bug in the current implementation of `BasicData#==`: it didn't check for the concrete type of BasicData object, which allowed for a situation where a card could be identified as being equal to a list (or any other subclass of `BasicData`).
