### PR TITLE
Adds custom fields

### DIFF
--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -52,6 +52,7 @@ module Trello
   autoload :Configuration,     'trello/configuration'
   autoload :CustomField,       'trello/custom_field'
   autoload :CustomFieldItem,   'trello/custom_field_item'
+  autoload :CustomFieldOption, 'trello/custom_field_option'
   autoload :HasActions,        'trello/has_actions'
   autoload :Item,              'trello/item'
   autoload :CheckItemState,    'trello/item_state'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -50,6 +50,7 @@ module Trello
   autoload :Checklist,         'trello/checklist'
   autoload :Client,            'trello/client'
   autoload :Configuration,     'trello/configuration'
+  autoload :CustomField,       'trello/custom_field'
   autoload :HasActions,        'trello/has_actions'
   autoload :Item,              'trello/item'
   autoload :CheckItemState,    'trello/item_state'

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -51,6 +51,7 @@ module Trello
   autoload :Client,            'trello/client'
   autoload :Configuration,     'trello/configuration'
   autoload :CustomField,       'trello/custom_field'
+  autoload :CustomFieldItem,   'trello/custom_field_item'
   autoload :HasActions,        'trello/has_actions'
   autoload :Item,              'trello/item'
   autoload :CheckItemState,    'trello/item_state'

--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -167,6 +167,9 @@ module Trello
     # Returns a list of plugins associated with the board
     many :plugin_data, path: "pluginData"
 
+    # Returns custom fields activated on this board
+    many :custom_fields, path: "customFields"
+
     def labels(params = {})
       # Set the limit to as high as possible given there is no pagination in this API.
       params[:limit] = 1000 unless params[:limit]

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -210,6 +210,9 @@ module Trello
     # Returns a list of plugins associated with the card
     many :plugin_data, path: "pluginData"
 
+    # List of custom field values on the card, only the ones that have been set
+    many :custom_field_items, path: 'customFieldItems'
+
     def check_item_states
       states = CheckItemState.from_response client.get("/cards/#{self.id}/checkItemStates")
       MultiAssociation.new(self, states).proxy

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -54,6 +54,9 @@ module Trello
     # Currently, model_type will always be "board" at the customFields endpoint
     one :board, path: :boards, using: :model_id
 
+    # If type == 'list'
+    many :custom_field_options, path: 'options'
+
     def update_fields(fields)
       attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || fields[:id] || attributes[:id]
       attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
@@ -94,6 +97,17 @@ module Trello
     # Also deletes all associated values across all cards
     def delete
       client.delete("/customFields/#{id}")
+    end
+
+    # If type == 'list', create a new option and add to this Custom Field
+    def create_new_option(value)
+      payload = { value: value }
+      client.post("/customFields/#{id}/options", payload)
+    end
+
+    # Will also clear it from individual cards that have this option selected
+    def delete_option(option_id)
+      client.delete("/customFields/#{id}/options/#{option_id}")
     end
   end
 end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -55,13 +55,13 @@ module Trello
     one :board, path: :boards, using: :model_id
 
     def update_fields(fields)
-      attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || attributes[:id]
-      attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || attributes[:name]
-      attributes[:model_id]    = fields[SYMBOL_TO_STRING[:model_id]] || attributes[:model_id]
-      attributes[:model_type]  = fields[SYMBOL_TO_STRING[:model_type]] || attributes[:model_type]
-      attributes[:field_group] = fields[SYMBOL_TO_STRING[:field_group]] || attributes[:field_group]
-      attributes[:type]        = fields[SYMBOL_TO_STRING[:type]] || attributes[:type]
-      attributes[:pos]         = fields[SYMBOL_TO_STRING[:pos]] || attributes[:pos]
+      attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || fields[:id] || attributes[:id]
+      attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
+      attributes[:model_id]    = fields[SYMBOL_TO_STRING[:model_id]] || fields[:model_id] || attributes[:model_id]
+      attributes[:model_type]  = fields[SYMBOL_TO_STRING[:model_type]] || fields[:model_type] || attributes[:model_type]
+      attributes[:field_group] = fields[SYMBOL_TO_STRING[:field_group]] || fields[:field_group] || attributes[:field_group]
+      attributes[:type]        = fields[SYMBOL_TO_STRING[:type]] || fields[:type] || attributes[:type]
+      attributes[:pos]         = fields[SYMBOL_TO_STRING[:pos]] || fields[:pos] || attributes[:pos]
       self
     end
 

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -1,0 +1,24 @@
+module Trello
+  # A Custom Field that can be activated on a board.
+  #
+  # @!attribute id
+  #   @return [String]
+  # @!attribute idModel
+  #   @return [String]
+  # @!attribute modelType
+  #   @return [String]
+  # @!attribute fieldGroup
+  #   @return [String]
+  # @!attribute name
+  #   @return [String]
+  # @!attribute pos
+  #   @return [Float]
+  # @!attribute type
+  #   @return [String]
+  # @!attribute options
+  #   @return [Array<Hash>]
+  class CustomField < BasicData
+    register_attributes :id, :idModel, :modelType, :fieldGroup, :name, :pos, :type
+
+  end
+end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -3,11 +3,11 @@ module Trello
   #
   # @!attribute id
   #   @return [String]
-  # @!attribute idModel
+  # @!attribute model_id
   #   @return [String]
-  # @!attribute modelType
+  # @!attribute model_type
   #   @return [String]
-  # @!attribute fieldGroup
+  # @!attribute field_group
   #   @return [String]
   # @!attribute name
   #   @return [String]
@@ -18,7 +18,69 @@ module Trello
   # @!attribute options
   #   @return [Array<Hash>]
   class CustomField < BasicData
-    register_attributes :id, :idModel, :modelType, :fieldGroup, :name, :pos, :type
+    register_attributes :id, :model_id, :model_type, :field_group, :name, :pos, :type
+    validates_presence_of :id, :model_id, :model_type, :name, :type, :pos
 
+    SYMBOL_TO_STRING = {
+      id:          'id',
+      name:        'name',
+      model_id:    'idModel',
+      model_type:  'modelType',
+      field_group: 'fieldGroup',
+      type:        'type',
+      pos:         'pos'
+    }
+
+    class << self
+      # Find a custom field by its id.
+      def find(id, params = {})
+        client.find(:custom_field, id, params)
+      end
+
+      # Create a new custom field and save it on Trello.
+      def create(options)
+        client.create(:custom_field,
+          'name'       => options[:name],
+          'idModel'    => options[:model_id],
+          'modelType'  => options[:model_type],
+          'fieldGroup' => options[:field_group],
+          'type'       => options[:type],
+          'pos'        => options[:pos]
+        )
+      end
+    end
+
+    def update_fields(fields)
+      attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || attributes[:id]
+      attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || attributes[:name]
+      attributes[:model_id]    = fields[SYMBOL_TO_STRING[:model_id]] || attributes[:model_id]
+      attributes[:model_type]  = fields[SYMBOL_TO_STRING[:model_type]] || attributes[:model_type]
+      attributes[:field_group] = fields[SYMBOL_TO_STRING[:field_group]] || attributes[:field_group]
+      attributes[:type]        = fields[SYMBOL_TO_STRING[:type]] || attributes[:type]
+      attributes[:pos]         = fields[SYMBOL_TO_STRING[:pos]] || attributes[:pos]
+      self
+    end
+
+    # Saves a record.
+    def save
+      # If we have an id, just update our fields.
+      return update! if id
+
+      from_response client.post("/customFields", {
+        name:       name,
+        color:      color,
+        idModel:    model_id,
+        modelType:  model_type,
+        type:       type,
+        pos:        pos,
+        fieldGroup: field_group
+      })
+    end
+
+    # Delete this custom field
+    # Also deletes all associated values across all cards
+    def delete
+      client.delete("/customFields/#{id}")
+    end
   end
 end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -34,12 +34,12 @@ module Trello
     class << self
       # Find a custom field by its id.
       def find(id, params = {})
-        client.find(:custom_field, id, params)
+        client.find('customFields', id, params)
       end
 
       # Create a new custom field and save it on Trello.
       def create(options)
-        client.create(:custom_field,
+        client.create('customFields',
           'name'       => options[:name],
           'idModel'    => options[:model_id],
           'modelType'  => options[:model_type],

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -1,17 +1,24 @@
 module Trello
+  # A custom field item contains the value for a custom field on a particular card.
+  #
   class CustomFieldItem < BasicData
-    register_attributes :id, :model_id, :model_type, :custom_field_id, :value
+    register_attributes :id, :model_id, :model_type, :custom_field_id, :value,
+                        readonly: [ :id, :custom_field_id, :model_id, :model_type ]
     validates_presence_of :id, :model_id, :custom_field_id
+
+    # References the card with this custom field value
+    one :card, path: :cards, using: :model_id
 
     # Update the fields of a custom field item.
     #
     # Supply a hash of string keyed data retrieved from the Trello API representing
     # an item state.
     def update_fields(fields)
-      attributes[:id]               = fields['id'] || attributes[:id]
-      attributes[:model_id]         = fields['idModel'] || attributes[:model_id]
-      attributes[:custom_field_id]  = fields['idCustomField'] || attributes[:custom_field_id]
-      attributes[:model_type]       = fields['modelType'] || attributes[:model_type]
+      attributes[:id]               = fields['id'] || fields[:id] || attributes[:id]
+      attributes[:model_id]         = fields['idModel'] || fields[:model_id] || attributes[:model_id]
+      attributes[:custom_field_id]  = fields['idCustomField'] || fields[:custom_field_id] || attributes[:custom_field_id]
+      attributes[:model_type]       = fields['modelType'] || fields[:model_type] || attributes[:model_type]
+      # value format: { "text": "hello world" }
       attributes[:value]            = fields['value'] if fields.has_key?('value')
       self
     end

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -19,14 +19,26 @@ module Trello
     def update!
       @previously_changed = changes
       # extract only new values to build payload
-      payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
+      payload = Hash[changes.map { |key, values| [key.to_sym, values[1]] }]
       @changed_attributes.clear
 
       client.put("/card/#{model_id}/customField/#{custom_field_id}/item", payload)
     end
 
-    # References the card with this custom field value
-    one :card, path: :cards, using: :model_id
+    # Saves a record.
+    #
+    # @raise [Trello::Error] if the card could not be saved
+    #
+    # @return [String] The JSON representation of the saved custom field item returned by
+    # the Trello API.
+    def save
+      # If we have an id, just update our fields.
+      return update! if id
+
+      from_response client.post("/card/#{model_id}/customField/#{custom_field_id}/item", {
+        value: value
+      })
+    end
 
     # You can't "delete" a custom field item, you can only clear the value
     def remove

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -9,6 +9,9 @@ module Trello
     # References the card with this custom field value
     one :card, path: :cards, using: :model_id
 
+    # References the parent custom field that this item is an instance of
+    one :custom_field, path: 'customFields', using: :custom_field_id
+
     # Update the fields of a custom field item.
     #
     # Supply a hash of string keyed data retrieved from the Trello API representing
@@ -51,6 +54,12 @@ module Trello
     def remove
       params = { value: {} }
       client.put("/card/#{model_id}/customField/#{custom_field_id}/item", params)
+    end
+
+    # Type is saved at the CustomField level
+    # Can equally be derived from :value, with a little parsing work: {"number": 42}
+    def type
+      custom_field.type
     end
   end
 end

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -1,0 +1,37 @@
+module Trello
+  class CustomFieldItem < BasicData
+    register_attributes :id, :model_id, :model_type, :custom_field_id, :value
+    validates_presence_of :id, :model_id, :custom_field_id
+
+    # Update the fields of a custom field item.
+    #
+    # Supply a hash of string keyed data retrieved from the Trello API representing
+    # an item state.
+    def update_fields(fields)
+      attributes[:id]               = fields['id'] || attributes[:id]
+      attributes[:model_id]         = fields['idModel'] || attributes[:model_id]
+      attributes[:custom_field_id]  = fields['idCustomField'] || attributes[:custom_field_id]
+      attributes[:model_type]       = fields['modelType'] || attributes[:model_type]
+      attributes[:value]            = fields['value'] if fields.has_key?('value')
+      self
+    end
+
+    def update!
+      @previously_changed = changes
+      # extract only new values to build payload
+      payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
+      @changed_attributes.clear
+
+      client.put("/card/#{model_id}/customField/#{custom_field_id}/item", payload)
+    end
+
+    # References the card with this custom field value
+    one :card, path: :cards, using: :model_id
+
+    # You can't "delete" a custom field item, you can only clear the value
+    def remove
+      params = { value: {} }
+      client.put("/card/#{model_id}/customField/#{custom_field_id}/item", params)
+    end
+  end
+end

--- a/lib/trello/custom_field_option.rb
+++ b/lib/trello/custom_field_option.rb
@@ -1,0 +1,22 @@
+module Trello
+  # A custom field option contains the individual items in a custom field dropdown menu.
+  #
+  class CustomFieldOption < BasicData
+    register_attributes :id, :value, :pos, :color,
+                        readonly: [:id]
+    validates_presence_of :id, :value
+
+    # Update the fields of a custom field option.
+    #
+    # Supply a hash of string keyed data retrieved from the Trello API representing
+    # an item state.
+    def update_fields(fields)
+      attributes[:id]               = fields['_id'] || fields[:id] || attributes[:id]
+      attributes[:color]            = fields['color'] || fields[:color] || attributes[:color]
+      attributes[:pos]              = fields['pos'] || fields[:pos] || attributes[:pos]
+      # value format: { "text": "hello world" }
+      attributes[:value]            = fields['value'] || fields[:value] || attributes[:value]
+      self
+    end
+  end
+end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -251,6 +251,19 @@ module Trello
       end
     end
 
+    context "custom fields" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/boards/abcdef123456789123456789/customFields", {})
+          .and_return JSON.generate([custom_fields_details.first])
+      end
+
+      it "has custom fields" do
+        expect(board.custom_fields.count).to be > 0
+      end
+    end
+
     it "is not closed" do
       expect(board).not_to be_closed
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -361,6 +361,18 @@ module Trello
 
         card.custom_field_items.last.remove
       end
+
+      it "updates a custom field value" do
+        payload = { value: { text: 'Test Text' } }
+
+        expect(client)
+          .to receive(:put)
+          .with("/card/abcdef123456789123456789/customField/abcdef123456789123456789/item", payload)
+
+        text_custom_field = card.custom_field_items.last
+        text_custom_field.value = { text: 'Test Text' }
+        text_custom_field.save
+      end
     end
 
     context "list" do

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -257,7 +257,6 @@ module Trello
         expect(card.pos).to_not be_nil
       end
 
-
       it 'gets its creation time' do
         expect(card.created_at).to be_kind_of Time
       end
@@ -338,6 +337,32 @@ module Trello
       end
     end
 
+    context "custom field items" do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abcdef123456789123456789/customFieldItems", {})
+          .and_return JSON.generate([custom_field_item_details])
+      end
+
+      it "has a list of custom field items" do
+        card.custom_field_items.each do |c|
+          puts c.value
+        end
+        expect(card.custom_field_items.count).to be > 0
+      end
+
+      it "clears the custom field value on a card" do
+        params = { value: {} }
+
+        expect(client)
+          .to receive(:put)
+          .with("/card/abcdef123456789123456789/customField/abcdef123456789123456789/item", params)
+
+        card.custom_field_items.last.remove
+      end
+    end
+
     context "list" do
       before do
         allow(client)
@@ -345,6 +370,7 @@ module Trello
           .with("/lists/abcdef123456789123456789", {})
           .and_return JSON.generate(lists_details.first)
       end
+
       it 'has a list' do
         expect(card.list).to_not be_nil
       end
@@ -555,7 +581,6 @@ module Trello
         expect(card.voters.first).to be_kind_of Trello::Member
       end
     end
-
 
     context "comments" do
       it "posts a comment" do

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -346,9 +346,6 @@ module Trello
       end
 
       it "has a list of custom field items" do
-        card.custom_field_items.each do |c|
-          puts c.value
-        end
         expect(card.custom_field_items.count).to be > 0
       end
 

--- a/spec/custom_field_item_spec.rb
+++ b/spec/custom_field_item_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+module Trello
+  describe CustomFieldItem do
+    include Helpers
+
+    let(:text_field_details) {
+      {
+        'id'   => 'abcdefgh12345678',
+        'value' => {"text": "Low Priority"},
+        'idValue' => nil,
+        'idModel' => 'abc123',
+        'idCustomField' => 'abcd1234',
+        'modelType' => 'card'
+      }
+    }
+
+    let(:list_item_details) {
+      {
+        'id'   => 'abcdefgh12345678',
+        'value' => nil,
+        'idValue' => 'abcde12345',
+        'idModel' => 'abc123',
+        'idCustomField' => 'abcd1234',
+        'modelType' => 'card'
+      }
+    }
+
+    let(:client) { Client.new }
+    let(:text_item) { CustomFieldItem.new(text_field_details) }
+    let(:list_item) { CustomFieldItem.new(list_item_details) }
+
+    it 'validates presence of id, model ID and custom field ID' do
+      invalid_item = CustomFieldItem.new
+
+      expect(invalid_item).to be_invalid
+      expect(invalid_item.errors).to include(:id)
+      expect(invalid_item.errors).to include(:model_id)
+      expect(invalid_item.errors).to include(:custom_field_id)
+    end
+
+    describe 'retrieve item fields' do
+      it 'gets its id' do
+        expect(text_item.id).to eq text_field_details['id']
+      end
+
+      it 'gets its value' do
+        expect(text_item.value).to eq text_field_details['value']
+      end
+
+      it 'gets its model type' do
+        expect(text_item.model_type).to eq text_field_details['modelType']
+      end
+
+      it 'gets its model ID' do
+        expect(text_item.model_id).to eq text_field_details['idModel']
+      end
+
+      it 'gets its custom field ID' do
+        expect(text_item.custom_field_id).to eq text_field_details['idCustomField']
+      end
+
+      it 'has a value ID for list option' do
+        expect(list_item.option_id).to eq list_item_details['idValue']
+      end
+    end
+
+    describe 'list option' do
+      let(:client) { Trello.client }
+
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/customFields/#{list_item.custom_field_id}/options/#{list_item.option_id}")
+          .and_return JSON.generate(custom_field_option_details)
+      end
+
+      it 'gets the value' do
+        expect(list_item.option_value).to_not be_nil
+      end
+    end
+
+    describe 'custom field' do
+      let(:client) { Trello.client }
+
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/customFields/abcd1234", {})
+          .and_return JSON.generate(custom_fields_details.first)
+      end
+
+      it 'has a custom field' do
+        expect(text_item.custom_field).to be_a CustomField
+        expect(text_item.custom_field.name).to eq('Priority')
+      end
+
+      it 'returns the custom field type' do
+        expect(text_item.type).to eq 'checkbox'
+      end
+    end
+
+    describe 'card' do
+      let(:client) { Trello.client }
+
+      before do
+        allow(client)
+          .to receive(:get)
+          .with("/cards/abc123", {})
+          .and_return JSON.generate(cards_details.first)
+      end
+
+      it 'has a card' do
+        expect(text_item.card).to be_a Card
+      end
+    end
+  end
+end

--- a/spec/custom_field_item_spec.rb
+++ b/spec/custom_field_item_spec.rb
@@ -7,7 +7,7 @@ module Trello
     let(:text_field_details) {
       {
         'id'   => 'abcdefgh12345678',
-        'value' => {"text": "Low Priority"},
+        'value' => {"text" => "Low Priority"},
         'idValue' => nil,
         'idModel' => 'abc123',
         'idCustomField' => 'abcd1234',

--- a/spec/custom_field_option_spec.rb
+++ b/spec/custom_field_option_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+module Trello
+  describe CustomFieldOption do
+    let(:details) {
+      {
+        '_id'   => 'abcdefgh12345678',
+        'value' => {"text": "Low Priority"},
+        'color' => 'green',
+        'pos' => 1
+      }
+    }
+
+    let(:option) { CustomFieldOption.new(details) }
+
+    it 'validates presence of value and id' do
+      invalid_option = CustomFieldOption.new
+
+      expect(invalid_option).to be_invalid
+      expect(invalid_option.errors).to include(:value)
+      expect(invalid_option.errors).to include(:id)
+    end
+
+    describe 'retrieve option fields' do
+      it 'gets its id' do
+        expect(option.id).to eq details['_id']
+      end
+
+      it 'gets its color' do
+        expect(option.color).to eq details['color']
+      end
+
+      it 'knows its value' do
+        expect(option.value).to eq details['value']
+      end
+
+      it 'gets its pos' do
+        expect(option.pos).to eq details['pos']
+      end
+    end
+
+    describe 'update fields' do
+      it 'allows fields to be updated' do
+        updated = {
+          color: "purple",
+          value: { "text": "Medium Priority" }
+        }
+
+        option.update_fields(updated)
+
+        expect(option.color).to eq "purple"
+        expect(option.value).to eq({"text": "Medium Priority"})
+      end
+    end
+  end
+end

--- a/spec/custom_field_option_spec.rb
+++ b/spec/custom_field_option_spec.rb
@@ -2,16 +2,9 @@ require 'spec_helper'
 
 module Trello
   describe CustomFieldOption do
-    let(:details) {
-      {
-        '_id'   => 'abcdefgh12345678',
-        'value' => {"text": "Low Priority"},
-        'color' => 'green',
-        'pos' => 1
-      }
-    }
+    include Helpers
 
-    let(:option) { CustomFieldOption.new(details) }
+    let(:option) { CustomFieldOption.new(custom_field_option_details) }
 
     it 'validates presence of value and id' do
       invalid_option = CustomFieldOption.new
@@ -23,19 +16,19 @@ module Trello
 
     describe 'retrieve option fields' do
       it 'gets its id' do
-        expect(option.id).to eq details['_id']
+        expect(option.id).to eq custom_field_option_details['_id']
       end
 
       it 'gets its color' do
-        expect(option.color).to eq details['color']
+        expect(option.color).to eq custom_field_option_details['color']
       end
 
       it 'knows its value' do
-        expect(option.value).to eq details['value']
+        expect(option.value).to eq custom_field_option_details['value']
       end
 
       it 'gets its pos' do
-        expect(option.pos).to eq details['pos']
+        expect(option.pos).to eq custom_field_option_details['pos']
       end
     end
 

--- a/spec/custom_field_option_spec.rb
+++ b/spec/custom_field_option_spec.rb
@@ -36,13 +36,13 @@ module Trello
       it 'allows fields to be updated' do
         updated = {
           color: "purple",
-          value: { "text": "Medium Priority" }
+          value: { "text" => "Medium Priority" }
         }
 
         option.update_fields(updated)
 
         expect(option.color).to eq "purple"
-        expect(option.value).to eq({"text": "Medium Priority"})
+        expect(option.value).to eq({"text" => "Medium Priority"})
       end
     end
   end

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -98,8 +98,62 @@ module Trello
       end
     end
 
-    context "deleting" do
-      it "deletes the custom field" do
+    context 'updating' do
+      it 'correctly updates custom field name' do
+        expected_new_name = 'Test Name'
+
+        payload = { name: expected_new_name }
+
+        expect(client)
+          .to receive(:put).once
+          .with('/customFields/abcdef123456789123456789', payload)
+
+        custom_field.name = expected_new_name
+        custom_field.save
+      end
+    end
+
+    context 'fields' do
+      it 'gets its id' do
+        expect(custom_field.id).to_not be_nil
+      end
+
+      it 'gets its name' do
+        expect(custom_field.name).to_not be_nil
+      end
+
+      it 'gets the model id' do
+        expect(custom_field.model_id).to_not be_nil
+      end
+
+      it 'gets the model type' do
+        expect(custom_field.model_type).to_not be_nil
+      end
+
+      it 'gets its type' do
+        expect(custom_field.type).to_not be_nil
+      end
+
+      it 'gets its position' do
+        expect(custom_field.pos).to_not be_nil
+      end
+    end
+
+    context 'boards' do
+      before do
+        allow(client)
+          .to receive(:get)
+          .with('/boards/abc123', {})
+          .and_return JSON.generate(boards_details.first)
+      end
+
+      it 'has a board' do
+        expect(custom_field.board).to_not be_nil
+      end
+    end
+
+    context 'deleting' do
+      it 'deletes the custom field' do
         expect(client)
           .to receive(:delete)
           .with("/customFields/#{custom_field.id}")

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -152,6 +152,26 @@ module Trello
       end
     end
 
+    context 'options' do
+      it 'creates a new option' do
+        payload = { "value": { "text": "High Priority" } }
+
+        expect(client)
+          .to receive(:post)
+          .with('/customFields/abcdef123456789123456789/options', payload)
+
+        custom_field.create_new_option({"text": "High Priority"})
+      end
+
+      it 'deletes option' do
+        expect(client)
+          .to receive(:delete)
+          .with('/customFields/abcdef123456789123456789/options/abc123')
+
+        custom_field.delete_option('abc123')
+      end
+    end
+
     context 'deleting' do
       it 'deletes the custom field' do
         expect(client)

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -10,19 +10,82 @@ module Trello
     before do
       allow(client)
         .to receive(:get)
-        .with("/customFields/abcdef123456789123456789", {})
+        .with('customFields/abcdef123456789123456789', {})
         .and_return custom_fields_payload
     end
 
-    context "finding" do
-      let(:client) { Client.new }
+    context 'creating' do
+      let(:client) { Trello.client }
+
+      it 'creates a new CustomField record' do
+        custom_fields_details.each do |details|
+          custom_field = CustomField.new(details)
+          expect(custom_field).to be_valid
+        end
+      end
+
+      it 'properly initializes all fields from response-like formatted hash' do
+        custom_field_details = custom_fields_details.first
+        custom_field = CustomField.new(custom_field_details)
+        expect(custom_field.id).to          eq(custom_field_details['id'])
+        expect(custom_field.name).to        eq(custom_field_details['name'])
+        expect(custom_field.type).to        eq(custom_field_details['type'])
+        expect(custom_field.pos).to         eq(custom_field_details['pos'])
+        expect(custom_field.model_id).to    eq(custom_field_details['idModel'])
+        expect(custom_field.model_type).to  eq(custom_field_details['modelType'])
+      end
+
+      it 'properly initializes all fields from options-like formatted hash' do
+        custom_field_details = custom_fields_details[1]
+        custom_field = CustomField.new(details)
+        expect(custom_field.id).to          eq(custom_field_details[:id])
+        expect(custom_field.name).to        eq(custom_field_details[:name])
+        expect(custom_field.type).to        eq(custom_field_details[:type])
+        expect(custom_field.pos).to         eq(custom_field_details[:pos])
+        expect(custom_field.model_id).to    eq(custom_field_details[:model_id])
+        expect(custom_field.model_type).to  eq(custom_field_details[:model_type])
+      end
+
+      it 'validates presence of id, name, model id, model type, type, and position' do
+        custom_field = CustomField.new
+        expect(custom_field).to_not be_valid
+        expect(custom_field.errors.count).to eq(6)
+        expect(custom_field.errors).to include(:name)
+        expect(custom_field.errors).to include(:id)
+        expect(custom_field.errors).to include(:model_id)
+        expect(custom_field.errors).to include(:model_type)
+        expect(custom_field.errors).to include(:pos)
+        expect(custom_field.errors).to include(:type)
+      end
+
+      it 'creates a new record and saves it on Trello', refactor: true do
+        test_payload = {
+          name: 'Test Custom Field'
+        }
+
+        result = JSON.generate(custom_fields_details.first.merge(test_payload))
+        expected_payload = {name: 'Test Custom Field', type: 'checkbox', idModel: 'abc123',
+                            modelType: 'board', pos: '123', fieldGroup: nil}
+
+        expect(client)
+          .to receive(:post)
+          .with('/customFields', expected_payload)
+          .and_return result
+
+        custom_field = CustomField.create(custom_fields_details[1].merge(test_payload))
+        expect(custom_field).to be_a CustomField
+      end
+    end
+
+    context 'finding' do
+      let(:client) { Trello.client }
 
       before do
         allow(client)
           .to receive(:find)
       end
 
-      it "delegates to Trello.client#find" do
+      it 'delegates to Trello.client#find' do
         expect(client)
           .to receive(:find)
           .with('customFields', 'abcdef123456789123456789', {})
@@ -30,7 +93,7 @@ module Trello
         CustomField.find('abcdef123456789123456789')
       end
 
-      it "is equivalent to client#find" do
+      it 'is equivalent to client#find' do
         expect(CustomField.find('abcdef123456789123456789')).to eq(custom_field)
       end
     end

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -154,13 +154,13 @@ module Trello
 
     context 'options' do
       it 'creates a new option' do
-        payload = { "value": { "text": "High Priority" } }
+        payload = { :value => { "text" => "High Priority" } }
 
         expect(client)
           .to receive(:post)
           .with('/customFields/abcdef123456789123456789/options', payload)
 
-        custom_field.create_new_option({"text": "High Priority"})
+        custom_field.create_new_option({"text" => "High Priority"})
       end
 
       it 'deletes option' do

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -65,7 +65,7 @@ module Trello
 
         result = JSON.generate(custom_fields_details.first.merge(test_payload))
         expected_payload = {name: 'Test Custom Field', type: 'checkbox', idModel: 'abc123',
-                            modelType: 'board', pos: '123', fieldGroup: nil}
+                            modelType: 'board', pos: 123, fieldGroup: nil}
 
         expect(client)
           .to receive(:post)

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+module Trello
+  describe CustomField do
+    include Helpers
+
+    let(:custom_field) { client.find('customFields', 'abcdef123456789123456789') }
+    let(:client) { Client.new }
+
+    before do
+      allow(client)
+        .to receive(:get)
+        .with("/customFields/abcdef123456789123456789", {})
+        .and_return custom_fields_payload
+    end
+
+    context "finding" do
+      let(:client) { Client.new }
+
+      before do
+        allow(client)
+          .to receive(:find)
+      end
+
+      it "delegates to Trello.client#find" do
+        expect(client)
+          .to receive(:find)
+          .with('customFields', 'abcdef123456789123456789', {})
+
+        CustomField.find('abcdef123456789123456789')
+      end
+
+      it "is equivalent to client#find" do
+        expect(CustomField.find('abcdef123456789123456789')).to eq(custom_field)
+      end
+    end
+  end
+end

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -10,7 +10,7 @@ module Trello
     before do
       allow(client)
         .to receive(:get)
-        .with('customFields/abcdef123456789123456789', {})
+        .with('/customFields/abcdef123456789123456789', {})
         .and_return custom_fields_payload
     end
 
@@ -37,7 +37,7 @@ module Trello
 
       it 'properly initializes all fields from options-like formatted hash' do
         custom_field_details = custom_fields_details[1]
-        custom_field = CustomField.new(details)
+        custom_field = CustomField.new(custom_field_details)
         expect(custom_field.id).to          eq(custom_field_details[:id])
         expect(custom_field.name).to        eq(custom_field_details[:name])
         expect(custom_field.type).to        eq(custom_field_details[:type])
@@ -95,6 +95,16 @@ module Trello
 
       it 'is equivalent to client#find' do
         expect(CustomField.find('abcdef123456789123456789')).to eq(custom_field)
+      end
+    end
+
+    context "deleting" do
+      it "deletes the custom field" do
+        expect(client)
+          .to receive(:delete)
+          .with("/customFields/#{custom_field.id}")
+
+        custom_field.delete
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -425,6 +425,21 @@ module Helpers
     JSON.generate(label_name_details)
   end
 
+  def custom_fields_details
+    {
+      'id' => 'abcdef123456789123456789',
+      'name' => 'Priority',
+      'idModel' => 'abc123',
+      'type' => 'checkbox',
+      'pos' => '123',
+      'modelType' => 'board'
+    }
+  end
+
+  def custom_fields_payload
+    JSON.generate(custom_fields_details)
+  end
+
   def webhooks_payload
     JSON.generate(webhooks_details)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -432,7 +432,7 @@ module Helpers
         'name' => 'Priority',
         'idModel' => 'abc123',
         'type' => 'checkbox',
-        'pos' => '123',
+        'pos' => 123,
         'modelType' => 'board'
       },
       {
@@ -440,7 +440,7 @@ module Helpers
         name: 'Priority',
         model_id: 'abc123',
         type: 'checkbox',
-        pos: '123',
+        pos: 123,
         model_type: 'board'
       }
     ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -450,6 +450,20 @@ module Helpers
     JSON.generate(custom_fields_details.first)
   end
 
+  def custom_field_item_details
+    {
+      'id' => 'abcdefg1234567',
+      'value' => {text: 'hello world'},
+      'idModel' => 'abcdef123456789123456789',
+      'idCustomField' => 'abcdef123456789123456789',
+      'modelType' => 'card'
+    }
+  end
+
+  def custom_field_items_payload
+    JSON.generate(custom_field_item_details)
+  end
+
   def webhooks_payload
     JSON.generate(webhooks_details)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -426,18 +426,28 @@ module Helpers
   end
 
   def custom_fields_details
-    {
-      'id' => 'abcdef123456789123456789',
-      'name' => 'Priority',
-      'idModel' => 'abc123',
-      'type' => 'checkbox',
-      'pos' => '123',
-      'modelType' => 'board'
-    }
+    [
+      {
+        'id' => 'abcdef123456789123456789',
+        'name' => 'Priority',
+        'idModel' => 'abc123',
+        'type' => 'checkbox',
+        'pos' => '123',
+        'modelType' => 'board'
+      },
+      {
+        id: 'abcdef123456789123456789',
+        name: 'Priority',
+        model_id: 'abc123',
+        type: 'checkbox',
+        pos: '123',
+        model_type: 'board'
+      }
+    ]
   end
 
   def custom_fields_payload
-    JSON.generate(custom_fields_details)
+    JSON.generate(custom_fields_details.first)
   end
 
   def webhooks_payload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -453,7 +453,7 @@ module Helpers
   def custom_field_item_details
     {
       'id' => 'abcdefg1234567',
-      'value' => {text: 'hello world'},
+      'value' => { text: 'hello world' },
       'idModel' => 'abcdef123456789123456789',
       'idCustomField' => 'abcdef123456789123456789',
       'modelType' => 'card'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -453,7 +453,7 @@ module Helpers
   def custom_field_option_details
     {
       '_id'   => 'abcdefgh12345678',
-      'value' => {"text": "Low Priority"},
+      'value' => {'text' => 'Low Priority'},
       'color' => 'green',
       'pos' => 1
     }
@@ -462,7 +462,7 @@ module Helpers
   def custom_field_item_details
     {
       'id' => 'abcdefg1234567',
-      'value' => { text: 'hello world' },
+      'value' => { 'text' => 'hello world' },
       'idModel' => 'abcdef123456789123456789',
       'idCustomField' => 'abcdef123456789123456789',
       'modelType' => 'card'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -450,6 +450,15 @@ module Helpers
     JSON.generate(custom_fields_details.first)
   end
 
+  def custom_field_option_details
+    {
+      '_id'   => 'abcdefgh12345678',
+      'value' => {"text": "Low Priority"},
+      'color' => 'green',
+      'pos' => 1
+    }
+  end
+
   def custom_field_item_details
     {
       'id' => 'abcdefg1234567',


### PR DESCRIPTION
A few months ago, Trello moved the Custom Fields Power-Up from `pluginData` to make it a core component of the Trello API ([Trello Docs](https://developers.trello.com/v1.0/docs/getting-started-custom-fields)). So the way the gem is written now you can no longer access data in the Custom Fields power-up.

I tried to organize it as intuitively as possible, but the API organizes things very strangely if you look through the links below and try to make sense of it. I can explain things if it doesn't make sense why I wrote it the way I did, or add more documentation if necessary.

Custom Field documentation: https://developers.trello.com/v1.0/reference#custom-fields
Custom Field Item documentation: https://developers.trello.com/v1.0/reference#setting-custom-field-values-on-cards