### PR TITLE
Remove the required presence of 'uses' field

### DIFF
--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -9,7 +9,7 @@ module Trello
   class Label < BasicData
     register_attributes :id, :name, :board_id, :uses,
       readonly: [ :id, :uses, :board_id ]
-    validates_presence_of :id, :uses, :board_id, :name
+    validates_presence_of :id, :board_id, :name
     validates_length_of   :name,        in: 1..16384
 
     SYMBOL_TO_STRING = {


### PR DESCRIPTION
Labels created on Trello don't seem to set anything for `uses`, thus it's always nil and labels will never pass the `Label#valid?` check, meaning that you can't remove labels from cards using the `ruby-trello` gem. 

Apologies, but I haven't done anything with the tests as there were 23 failures from a clean fork and I'm not here to fix those!