### PR TITLE
Install latest version of bundler in the 1.x series on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ rvm:
   - 2.4.0
   - jruby-head
 before_install:
-  - gem install bundler
-  - gem update bundler
+  - gem install bundler -v '~> 1.0'
 env:
   - ACTIVE_MODEL_VERSION='~> 3.2.0'
   - ACTIVE_MODEL_VERSION='~> 4.0'


### PR DESCRIPTION
Bundler >= 2.0 requires Ruby version >= 2.3.0. 

As of January 3, 2019, Bundler >= 2.0 is the default version installed by RubyGems. 

This causes the majority of builds for `ruby-trello` to break on Travis. 

While Ruby versions <= 2.3.0 are supported by `ruby-trello`, the builds should continue to work. 

Use the [pessimistic version constraint](https://guides.rubygems.org/patterns/#pessimistic-version-constraint) to install the latest version of bundler in the 1.x series on Travis. 