### PR TITLE
Compatible with Active Model 5.2

### DIFF
--- a/lib/trello/basic_data.rb
+++ b/lib/trello/basic_data.rb
@@ -49,16 +49,16 @@ module Trello
       # Defines the attribute getter and setters.
       class_eval do
         define_method :attributes do
-          @attributes ||= names.reduce({}) { |hash, k| hash.merge(k.to_sym => nil) }
+          @__attributes ||= names.reduce({}) { |hash, k| hash.merge(k.to_sym => nil) }
         end
 
         names.each do |key|
-          define_method(:"#{key}") { @attributes[key] }
+          define_method(:"#{key}") { @__attributes[key] }
 
           unless options[:readonly].include?(key.to_sym)
             define_method :"#{key}=" do |val|
-              send(:"#{key}_will_change!") unless val == @attributes[key]
-              @attributes[key] = val
+              send(:"#{key}_will_change!") unless val == @__attributes[key]
+              @__attributes[key] = val
             end
           end
         end

--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -72,7 +72,8 @@ module Trello
       fail "Cannot save new instance." unless self.id
 
       @previously_changed = changes
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       fields = {
         name: attributes[:name],

--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -73,7 +73,7 @@ module Trello
 
       @previously_changed = changes
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       fields = {
         name: attributes[:name],

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -278,7 +278,7 @@ module Trello
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       client.put("/cards/#{id}", payload)
     end

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -277,7 +277,8 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       client.put("/cards/#{id}", payload)
     end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -88,7 +88,8 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       client.put("/customFields/#{id}", payload)
     end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -89,7 +89,7 @@ module Trello
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       client.put("/customFields/#{id}", payload)
     end

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -34,7 +34,7 @@ module Trello
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [key.to_sym, values[1]] }]
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       client.put("/card/#{model_id}/customField/#{custom_field_id}/item", payload)
     end

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -33,7 +33,8 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [key.to_sym, values[1]] }]
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       client.put("/card/#{model_id}/customField/#{custom_field_id}/item", payload)
     end

--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -46,7 +46,7 @@ module Trello
     define_attribute_methods [:color]
 
     def color
-      @attributes[:color]
+      @__attributes[:color]
     end
 
     def color= colour
@@ -55,8 +55,8 @@ module Trello
         return Trello.logger.warn "The label colour '#{colour}' does not exist."
       end
 
-      self.send(:"color_will_change!") unless colour == @attributes[:color]
-      @attributes[:color] = colour
+      self.send(:"color_will_change!") unless colour == @__attributes[:color]
+      @__attributes[:color] = colour
     end
 
     # Update the fields of a label.
@@ -95,7 +95,8 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       client.put("/labels/#{id}", payload)
     end

--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -96,7 +96,7 @@ module Trello
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       client.put("/labels/#{id}", payload)
     end

--- a/lib/trello/member.rb
+++ b/lib/trello/member.rb
@@ -93,7 +93,7 @@ module Trello
     def save
       @previously_changed = changes
       @changed_attributes.try(:clear)
-      try(:changes_applied)
+      changes_applied if respond_to?(:changes_applied)
 
       return update! if id
     end

--- a/lib/trello/member.rb
+++ b/lib/trello/member.rb
@@ -92,7 +92,8 @@ module Trello
 
     def save
       @previously_changed = changes
-      @changed_attributes.clear
+      @changed_attributes.try(:clear)
+      try(:changes_applied)
 
       return update! if id
     end


### PR DESCRIPTION
I have done a fix to compatible with Active Model 5.2.

- Change`@attributes` to `@__attributes`
  - Prevent Dirty to use `ActiveModel::AttributeMutationTracker`.
  - Ref: [dirty source code](https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/dirty.rb#L264-L268)
- Add `changes_applied` method for save
  - [Rails 5 Dirty doc](https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/dirty.rb#L45-L49)
  - [Rails 4 Dirty doc](https://github.com/rails/rails/blob/v4.0.7/activemodel/lib/active_model/dirty.rb#L41-L44)