### PR TITLE
Add language key to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 rvm:
   - 2.1.0
   - 2.1.1


### PR DESCRIPTION
From [the TravisCI docs][1]:

> Language-specific workers have multiple runtimes for their respective
> language (for example, Ruby workers have about 10 Ruby
> versions/implementations).

Setting the `language` key should speed up and stabilize builds for Ruby
versions that are already installed on TravisCI.

[1]: https://docs.travis-ci.com/user/reference/precise/#runtimes