### PR TITLE
Fix #update_field issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,37 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.1.1
-  - 2.1.5
-  - 2.1.6
-  - 2.1.7
-  - 2.1.8
-  - 2.1.9
   - 2.1.10
-  - 2.2.0
   - 2.2.1
   - 2.2.2
-  - 2.2.3
-  - 2.2.4
-  - 2.2.5
-  - 2.2.6
-  - 2.3.0
-  - 2.3.1
-  - 2.3.2
-  - 2.3.3
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.2.10
+  - 2.3.8
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
   - 2.7.0
 before_install:
   - gem install bundler -v '~> 1.0'
 env:
   - ACTIVE_MODEL_VERSION='~> 3.2.0'
   - ACTIVE_MODEL_VERSION='~> 4.0'
+  - ACTIVE_MODEL_VERSION='~> 5.1'
+  - ACTIVE_MODEL_VERSION='~> 5.2'
+jobs:
+  exclude:
+    - rvm: 2.1.10
+      env: ACTIVE_MODEL_VERSION='~> 5.1'
+    - rvm: 2.1.10
+      env: ACTIVE_MODEL_VERSION='~> 5.2'
+    - rvm: 2.2.1
+      env: ACTIVE_MODEL_VERSION='~> 5.1'
+    - rvm: 2.2.1
+      env: ACTIVE_MODEL_VERSION='~> 5.2'
+    - rvm: 2.7.0
+      env: ACTIVE_MODEL_VERSION='~> 3.2.0'
+    - rvm: 2.7.0
+      env: ACTIVE_MODEL_VERSION='~> 4.0'
+    - rvm: 2.7.0
+      env: ACTIVE_MODEL_VERSION='~> 5.1'
 gemfile: Gemfile
 notifications:
   recipients:

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development, :spec do
   gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
   gem 'webmock'
   gem 'launchy'
+  gem 'pry-byebug'
 end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Supports Ruby 2.1.0 or newer.
 Use version 1.3.0 or earlier for Ruby 1.9.3 support.
 Use version 1.4.x or earlier for Ruby 2.0.0 support.
 
+Ruby 2.7.0 or newer only works with Rails 2.2.0 or newer.
+
 ## Configuration
 
 #### Basic authorization:

--- a/lib/trello/board.rb
+++ b/lib/trello/board.rb
@@ -72,7 +72,7 @@ module Trello
       fail "Cannot save new instance." unless self.id
 
       @previously_changed = changes
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       fields = {

--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -169,30 +169,19 @@ module Trello
     #
     # @return [Trello::Card] self
     def update_fields(fields)
-      attributes[:id]                     = fields[SYMBOL_TO_STRING[:id]] || attributes[:id]
-      attributes[:short_id]               = fields[SYMBOL_TO_STRING[:short_id]] || attributes[:short_id]
-      attributes[:name]                   = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
-      attributes[:desc]                   = fields[SYMBOL_TO_STRING[:desc]] || fields[:desc] || attributes[:desc]
-      attributes[:due]                    = Time.iso8601(fields[SYMBOL_TO_STRING[:due]]) rescue nil if fields.has_key?(SYMBOL_TO_STRING[:due])
-      attributes[:due]                    = fields[:due] if fields.has_key?(:due)
-      attributes[:due_complete]           = fields[SYMBOL_TO_STRING[:due_complete]] if fields.has_key?(SYMBOL_TO_STRING[:due_complete])
-      attributes[:due_complete]           ||= false
-      attributes[:closed]                 = fields[SYMBOL_TO_STRING[:closed]] if fields.has_key?(SYMBOL_TO_STRING[:closed])
-      attributes[:url]                    = fields[SYMBOL_TO_STRING[:url]] || attributes[:url]
-      attributes[:short_url]              = fields[SYMBOL_TO_STRING[:short_url]] || attributes[:short_url]
-      attributes[:board_id]               = fields[SYMBOL_TO_STRING[:board_id]] || attributes[:board_id]
-      attributes[:member_ids]             = fields[SYMBOL_TO_STRING[:member_ids]] || fields[:member_ids] || attributes[:member_ids]
-      attributes[:list_id]                = fields[SYMBOL_TO_STRING[:list_id]] || fields[:list_id] || attributes[:list_id]
-      attributes[:pos]                    = fields[SYMBOL_TO_STRING[:pos]] || fields[:pos] || attributes[:pos]
-      attributes[:labels]                 = (fields[SYMBOL_TO_STRING[:labels]] || []).map { |lbl| Trello::Label.new(lbl) }.presence || attributes[:labels].presence || []
-      attributes[:card_labels]            = fields[SYMBOL_TO_STRING[:card_labels]] || fields[:card_labels] || attributes[:card_labels]
-      attributes[:last_activity_date]     = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil if fields.has_key?(SYMBOL_TO_STRING[:last_activity_date])
-      attributes[:cover_image_id]         = fields[SYMBOL_TO_STRING[:cover_image_id]] || attributes[:cover_image_id]
-      attributes[:badges]                 = fields[SYMBOL_TO_STRING[:badges]] || attributes[:badges]
-      attributes[:card_members]           = fields[SYMBOL_TO_STRING[:card_members]] || attributes[:card_members]
-      attributes[:source_card_id]         = fields[SYMBOL_TO_STRING[:source_card_id]] || fields[:source_card_id] || attributes[:source_card_id]
-      attributes[:source_card_properties] = fields[SYMBOL_TO_STRING[:source_card_properties]] || fields[:source_card_properties] || attributes[:source_card_properties]
-      self
+      %i[
+        name desc due due_complete closed
+        board_id member_ids list_id pos
+        card_labels cover_image_id
+      ].each do |key|
+        send("#{key}_will_change!") if fields_has_key?(fields, key)
+      end
+
+      initialize_fields(fields)
+    end
+
+    def initialize(fields = {})
+      initialize_fields(fields)
     end
 
     # Returns a reference to the board this card is part of.
@@ -277,7 +266,7 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       client.put("/cards/#{id}", payload)
@@ -465,5 +454,37 @@ module Trello
     def me
       @me ||= Member.find(:me)
     end
+
+    def fields_has_key?(fields, key)
+      fields.key?(SYMBOL_TO_STRING[key]) || fields.key?(key)
+    end
+
+    def initialize_fields(fields)
+      attributes[:id]                     = fields[SYMBOL_TO_STRING[:id]] || attributes[:id]
+      attributes[:short_id]               = fields[SYMBOL_TO_STRING[:short_id]] || attributes[:short_id]
+      attributes[:name]                   = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
+      attributes[:desc]                   = fields[SYMBOL_TO_STRING[:desc]] || fields[:desc] || attributes[:desc]
+      attributes[:due]                    = Time.iso8601(fields[SYMBOL_TO_STRING[:due]]) rescue nil if fields.has_key?(SYMBOL_TO_STRING[:due])
+      attributes[:due]                    = fields[:due] if fields.has_key?(:due)
+      attributes[:due_complete]           = fields[SYMBOL_TO_STRING[:due_complete]] if fields.has_key?(SYMBOL_TO_STRING[:due_complete])
+      attributes[:due_complete]           ||= false
+      attributes[:closed]                 = fields[SYMBOL_TO_STRING[:closed]] if fields.has_key?(SYMBOL_TO_STRING[:closed])
+      attributes[:url]                    = fields[SYMBOL_TO_STRING[:url]] || attributes[:url]
+      attributes[:short_url]              = fields[SYMBOL_TO_STRING[:short_url]] || attributes[:short_url]
+      attributes[:board_id]               = fields[SYMBOL_TO_STRING[:board_id]] || attributes[:board_id]
+      attributes[:member_ids]             = fields[SYMBOL_TO_STRING[:member_ids]] || fields[:member_ids] || attributes[:member_ids]
+      attributes[:list_id]                = fields[SYMBOL_TO_STRING[:list_id]] || fields[:list_id] || attributes[:list_id]
+      attributes[:pos]                    = fields[SYMBOL_TO_STRING[:pos]] || fields[:pos] || attributes[:pos]
+      attributes[:labels]                 = (fields[SYMBOL_TO_STRING[:labels]] || []).map { |lbl| Trello::Label.new(lbl) }.presence || attributes[:labels].presence || []
+      attributes[:card_labels]            = fields[SYMBOL_TO_STRING[:card_labels]] || fields[:card_labels] || attributes[:card_labels]
+      attributes[:last_activity_date]     = Time.iso8601(fields[SYMBOL_TO_STRING[:last_activity_date]]) rescue nil if fields.has_key?(SYMBOL_TO_STRING[:last_activity_date])
+      attributes[:cover_image_id]         = fields[SYMBOL_TO_STRING[:cover_image_id]] || attributes[:cover_image_id]
+      attributes[:badges]                 = fields[SYMBOL_TO_STRING[:badges]] || attributes[:badges]
+      attributes[:card_members]           = fields[SYMBOL_TO_STRING[:card_members]] || attributes[:card_members]
+      attributes[:source_card_id]         = fields[SYMBOL_TO_STRING[:source_card_id]] || fields[:source_card_id] || attributes[:source_card_id]
+      attributes[:source_card_properties] = fields[SYMBOL_TO_STRING[:source_card_properties]] || fields[:source_card_properties] || attributes[:source_card_properties]
+      self
+    end
+
   end
 end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -58,14 +58,14 @@ module Trello
     many :custom_field_options, path: 'options'
 
     def update_fields(fields)
-      attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || fields[:id] || attributes[:id]
-      attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
-      attributes[:model_id]    = fields[SYMBOL_TO_STRING[:model_id]] || fields[:model_id] || attributes[:model_id]
-      attributes[:model_type]  = fields[SYMBOL_TO_STRING[:model_type]] || fields[:model_type] || attributes[:model_type]
-      attributes[:field_group] = fields[SYMBOL_TO_STRING[:field_group]] || fields[:field_group] || attributes[:field_group]
-      attributes[:type]        = fields[SYMBOL_TO_STRING[:type]] || fields[:type] || attributes[:type]
-      attributes[:pos]         = fields[SYMBOL_TO_STRING[:pos]] || fields[:pos] || attributes[:pos]
-      self
+      send('name_will_change!') if fields_has_key?(fields, :name)
+      send('pos_will_change!') if fields_has_key?(fields, :pos)
+
+      initialize_fields(fields)
+    end
+
+    def initialize(fields = {})
+      initialize_fields(fields)
     end
 
     # Saves a record.
@@ -109,6 +109,23 @@ module Trello
     # Will also clear it from individual cards that have this option selected
     def delete_option(option_id)
       client.delete("/customFields/#{id}/options/#{option_id}")
+    end
+
+    private
+
+    def fields_has_key?(fields, key)
+      fields.key?(SYMBOL_TO_STRING[key]) || fields.key?(key)
+    end
+
+    def initialize_fields(fields)
+      attributes[:id]          = fields[SYMBOL_TO_STRING[:id]] || fields[:id] || attributes[:id]
+      attributes[:name]        = fields[SYMBOL_TO_STRING[:name]] || fields[:name] || attributes[:name]
+      attributes[:model_id]    = fields[SYMBOL_TO_STRING[:model_id]] || fields[:model_id] || attributes[:model_id]
+      attributes[:model_type]  = fields[SYMBOL_TO_STRING[:model_type]] || fields[:model_type] || attributes[:model_type]
+      attributes[:field_group] = fields[SYMBOL_TO_STRING[:field_group]] || fields[:field_group] || attributes[:field_group]
+      attributes[:type]        = fields[SYMBOL_TO_STRING[:type]] || fields[:type] || attributes[:type]
+      attributes[:pos]         = fields[SYMBOL_TO_STRING[:pos]] || fields[:pos] || attributes[:pos]
+      self
     end
   end
 end

--- a/lib/trello/custom_field.rb
+++ b/lib/trello/custom_field.rb
@@ -88,7 +88,7 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       client.put("/customFields/#{id}", payload)

--- a/lib/trello/custom_field_item.rb
+++ b/lib/trello/custom_field_item.rb
@@ -33,7 +33,7 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [key.to_sym, values[1]] }]
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       client.put("/card/#{model_id}/customField/#{custom_field_id}/item", payload)

--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -64,12 +64,14 @@ module Trello
     # Supply a hash of stringkeyed data retrieved from the Trello API representing
     # a label.
     def update_fields(fields)
-      attributes[:id] = fields['id'] || attributes[:id]
-      attributes[:name]  = fields['name'] || fields[:name] || attributes[:name]
-      attributes[:color] = fields['color'] || fields[:color] || attributes[:color]
-      attributes[:board_id] = fields['idBoard'] || fields[:board_id] || attributes[:board_id]
-      attributes[:uses] = fields['uses'] if fields.has_key?('uses')
-      self
+      send('name_will_change!') if fields_has_key?(fields, :name)
+      send('color_will_change!') if fields_has_key?(fields, :color)
+
+      initialize_fields(fields)
+    end
+
+    def initialize(fields = {})
+      initialize_fields(fields)
     end
 
     # Returns a reference to the board this label is currently connected.
@@ -104,6 +106,21 @@ module Trello
     # Delete this label
     def delete
       client.delete("/labels/#{id}")
+    end
+
+    private
+
+    def fields_has_key?(fields, key)
+      fields.key?(SYMBOL_TO_STRING[key]) || fields.key?(key)
+    end
+
+    def initialize_fields(fields)
+      attributes[:id] = fields['id'] || attributes[:id]
+      attributes[:name]  = fields['name'] || fields[:name] || attributes[:name]
+      attributes[:color] = fields['color'] || fields[:color] || attributes[:color]
+      attributes[:board_id] = fields['idBoard'] || fields[:board_id] || attributes[:board_id]
+      attributes[:uses] = fields['uses'] if fields.has_key?('uses')
+      self
     end
   end
 end

--- a/lib/trello/label.rb
+++ b/lib/trello/label.rb
@@ -95,7 +95,7 @@ module Trello
       @previously_changed = changes
       # extract only new values to build payload
       payload = Hash[changes.map { |key, values| [SYMBOL_TO_STRING[key.to_sym].to_sym, values[1]] }]
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       client.put("/labels/#{id}", payload)

--- a/lib/trello/member.rb
+++ b/lib/trello/member.rb
@@ -92,7 +92,7 @@ module Trello
 
     def save
       @previously_changed = changes
-      @changed_attributes.try(:clear)
+      @changed_attributes.clear if @changed_attributes.respond_to?(:clear)
       changes_applied if respond_to?(:changes_applied)
 
       return update! if id

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -827,28 +827,97 @@ module Trello
       end
     end
 
-    describe "#update_fields" do
-      it "does not set any fields when the fields argument is empty" do
-        expected = cards_details.first
+    describe '#update_fields' do
+      context 'when the fields argument is empty' do
+        let(:fields) { {} }
 
-        card = Card.new(expected)
-        card.client = client
+        it 'card does not set any fields' do
+          expected = cards_details.first
 
-        card.update_fields({})
+          card = Card.new(expected)
+          card.client = client
 
-        expected.each do |key, value|
-          if card.respond_to?(key) && key != 'labels'
-            expect(card.send(key)).to eq value
+          card.update_fields(fields)
+
+          expected.each do |key, value|
+            if card.respond_to?(key) && key != 'labels'
+              expect(card.send(key)).to eq value
+            end
+
+            expect(card.labels).to eq expected['labels'].map { |lbl| Trello::Label.new(lbl) }
+            expect(card.short_id).to eq expected['idShort']
+            expect(card.short_url).to eq expected['shortUrl']
+            expect(card.board_id).to eq expected['idBoard']
+            expect(card.member_ids).to eq expected['idMembers']
+            expect(card.cover_image_id).to eq expected['idAttachmentCover']
+            expect(card.list_id).to eq expected['idList']
+            expect(card.card_labels).to eq expected['idLabels']
+          end
+        end
+      end
+
+      context 'when the fields argument has at least one field' do
+        let(:expected) { cards_details.first }
+        let(:card) {
+          card = Card.new(expected)
+          card.client = client
+          card
+        }
+
+        context 'and the field does changed' do
+          let(:fields) { { desc: 'Awesome things have changed.' } }
+
+          it 'card does set the changed fields' do
+            card.update_fields(fields)
+
+            expect(card.desc).to eq('Awesome things have changed.')
           end
 
-          expect(card.labels).to eq expected['labels'].map { |lbl| Trello::Label.new(lbl) }
-          expect(card.short_id).to eq expected['idShort']
-          expect(card.short_url).to eq expected['shortUrl']
-          expect(card.board_id).to eq expected['idBoard']
-          expect(card.member_ids).to eq expected['idMembers']
-          expect(card.cover_image_id).to eq expected['idAttachmentCover']
-          expect(card.list_id).to eq expected['idList']
-          expect(card.card_labels).to eq expected['idLabels']
+          it 'card has been mark as changed' do
+            card.update_fields(fields)
+
+            expect(card.changed?).to be_truthy
+          end
+        end
+
+        context "and the field doesn't changed" do
+          let(:fields) { { desc: expected[:desc] } }
+
+          it "card attributes doesn't changed" do
+            card.update_fields(fields)
+
+            expect(card.desc).to eq(expected['desc'])
+          end
+
+          it "card hasn't been mark as changed", pending: true do
+            card.update_fields(fields)
+
+            expect(card.changed?).to be_falsy
+          end
+        end
+
+        context "and the field isn't a correct attributes of the card" do
+          let(:fields) { { abc: 'abc' } }
+
+          it "card attributes doesn't changed" do
+            card.update_fields(fields)
+
+            expect(card.labels).to eq expected['labels'].map { |lbl| Trello::Label.new(lbl) }
+            expect(card.short_id).to eq expected['idShort']
+            expect(card.short_url).to eq expected['shortUrl']
+            expect(card.board_id).to eq expected['idBoard']
+            expect(card.member_ids).to eq expected['idMembers']
+            expect(card.cover_image_id).to eq expected['idAttachmentCover']
+            expect(card.list_id).to eq expected['idList']
+            expect(card.card_labels).to eq expected['idLabels']
+            expect(card.desc).to eq expected['desc']
+          end
+
+          it "card hasn't been mark as changed" do
+            card.update_fields(fields)
+
+            expect(card.changed?).to be_falsy
+          end
         end
       end
     end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -473,7 +473,7 @@ module Trello
         card.move_to_list_on_any_board(other_list.id)
       end
 
-      it 'should not be moved if new board is identical with old board', focus: true do
+      it 'should not be moved if new board is identical with old board' do
         other_board = double(id: 'abcdef123456789123456789')
         expect(client).to_not receive(:put)
         card.move_to_board(other_board)

--- a/spec/custom_field_item_spec.rb
+++ b/spec/custom_field_item_spec.rb
@@ -114,5 +114,79 @@ module Trello
         expect(text_item.card).to be_a Card
       end
     end
+
+    describe '#update_fields' do
+
+      context 'when the fields argument is empty' do
+        let(:fields) { {} }
+
+        it 'custom field item does not set any fields' do
+          text_item.update_fields(fields)
+
+          expect(text_item.id).to eq text_field_details['id']
+          expect(text_item.option_id).to eq text_field_details['idValue']
+          expect(text_item.model_id).to eq text_field_details['idModel']
+          expect(text_item.custom_field_id).to eq text_field_details['idCustomField']
+          expect(text_item.model_type).to eq text_field_details['modelType']
+          expect(text_item.value).to eq text_field_details['value']
+        end
+      end
+
+      context 'when the fields argument has at least one field' do
+
+        context 'and the field does changed' do
+          let(:fields) { { value: { number: '42' } } }
+
+          it 'custom field item does set the changed fields' do
+            text_item.update_fields(fields)
+
+            expect(text_item.value).to eq( { number: '42' } )
+          end
+
+          it 'card has been mark as changed' do
+            text_item.update_fields(fields)
+
+            expect(text_item.changed?).to be_truthy
+          end
+        end
+
+        context "and the field doesn't changed" do
+          let(:fields) { { value: text_field_details['value'] } }
+
+          it "custom field item attributes doesn't changed" do
+            text_item.update_fields(fields)
+
+            expect(text_item.value).to eq(text_field_details['value'])
+          end
+
+          it "custom field item hasn't been mark as changed", pending: true do
+            text_item.update_fields(fields)
+
+            expect(text_item.changed?).to be_falsy
+          end
+        end
+
+        context "and the field isn't a correct attributes of the card" do
+          let(:fields) { { abc: 'abc' } }
+
+          it "custom field item attributes doesn't changed" do
+            text_item.update_fields(fields)
+
+            expect(text_item.id).to eq text_field_details['id']
+            expect(text_item.option_id).to eq text_field_details['idValue']
+            expect(text_item.model_id).to eq text_field_details['idModel']
+            expect(text_item.custom_field_id).to eq text_field_details['idCustomField']
+            expect(text_item.model_type).to eq text_field_details['modelType']
+            expect(text_item.value).to eq text_field_details['value']
+          end
+
+          it "custom field item hasn't been mark as changed" do
+            text_item.update_fields(fields)
+
+            expect(text_item.changed?).to be_falsy
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/custom_field_spec.rb
+++ b/spec/custom_field_spec.rb
@@ -181,5 +181,81 @@ module Trello
         custom_field.delete
       end
     end
+
+    describe '#update_fields' do
+      let(:custom_field_detail) { custom_fields_details.first }
+      let(:custom_field) { CustomField.new(custom_field_detail) }
+
+      context 'when the fields argument is empty' do
+        let(:fields) { {} }
+
+        it 'custom field does not set any fields' do
+          custom_field.update_fields(fields)
+
+          expect(custom_field.id).to eq custom_field_detail['id']
+          expect(custom_field.model_id).to eq custom_field_detail['idModel']
+          expect(custom_field.model_type).to eq custom_field_detail['modelType']
+          expect(custom_field.name).to eq custom_field_detail['name']
+          expect(custom_field.pos).to eq custom_field_detail['pos']
+          expect(custom_field.type).to eq custom_field_detail['type']
+        end
+      end
+
+      context 'when the fields argument has at least one field' do
+        context 'and the field does changed' do
+          let(:fields) { { name: 'Awesome Name' } }
+
+          it 'custom field does set the changed fields' do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.name).to eq('Awesome Name')
+          end
+
+          it 'custom field has been mark as changed' do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.changed?).to be_truthy
+          end
+        end
+
+        context "and the field doesn't changed" do
+          let(:fields) { { name: custom_field_detail['name'] } }
+
+          it "custom field attributes doesn't changed" do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.name).to eq(custom_field_detail['name'])
+          end
+
+          it "custom field hasn't been mark as changed", pending: true do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.changed?).to be_falsy
+          end
+        end
+
+        context "and the field isn't a correct attributes of the card" do
+          let(:fields) { { abc: 'abc' } }
+
+          it "custom field attributes doesn't changed" do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.id).to eq custom_field_detail['id']
+            expect(custom_field.model_id).to eq custom_field_detail['idModel']
+            expect(custom_field.model_type).to eq custom_field_detail['modelType']
+            expect(custom_field.name).to eq custom_field_detail['name']
+            expect(custom_field.pos).to eq custom_field_detail['pos']
+            expect(custom_field.type).to eq custom_field_detail['type']
+          end
+
+          it "custom field hasn't been mark as changed" do
+            custom_field.update_fields(fields)
+
+            expect(custom_field.changed?).to be_falsy
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -201,5 +201,84 @@ module Trello
         end
       end
     end
+
+    describe '#update_fields' do
+      let(:label_detail) {{
+        'id' => 'id',
+        'name' => 'name',
+        'color' => 'color',
+        'idBoard' => 'board_id',
+        'uses' => 'uses'
+      }}
+      let(:label) { Label.new(label_detail) }
+
+      context 'when the fields argument is empty' do
+        let(:fields) { {} }
+
+        it 'card does not set any fields' do
+          label.update_fields(fields)
+
+          expect(label.id).to eq label_detail['id']
+          expect(label.name).to eq label_detail['name']
+          expect(label.color).to eq label_detail['color']
+          expect(label.board_id).to eq label_detail['idBoard']
+          expect(label.uses).to eq label_detail['uses']
+        end
+      end
+
+      context 'when the fields argument has at least one field' do
+        context 'and the field does changed' do
+          let(:fields) { { name: 'Awesome Name' } }
+
+          it 'label does set the changed fields' do
+            label.update_fields(fields)
+
+            expect(label.name).to eq('Awesome Name')
+          end
+
+          it 'label has been mark as changed' do
+            label.update_fields(fields)
+
+            expect(label.changed?).to be_truthy
+          end
+        end
+
+        context "and the field doesn't changed" do
+          let(:fields) { { name: label_detail['name'] } }
+
+          it "label attributes doesn't changed" do
+            label.update_fields(fields)
+
+            expect(label.name).to eq(label_detail['name'])
+          end
+
+          it "label hasn't been mark as changed", pending: true do
+            label.update_fields(fields)
+
+            expect(label.changed?).to be_falsy
+          end
+        end
+
+        context "and the field isn't a correct attributes of the label" do
+          let(:fields) { { abc: 'abc' } }
+
+          it "label attributes doesn't changed" do
+            label.update_fields(fields)
+
+            expect(label.id).to eq label_detail['id']
+            expect(label.name).to eq label_detail['name']
+            expect(label.color).to eq label_detail['color']
+            expect(label.board_id).to eq label_detail['idBoard']
+            expect(label.uses).to eq label_detail['uses']
+          end
+
+          it "label hasn't been mark as changed" do
+            label.update_fields(fields)
+
+            expect(label.changed?).to be_falsy
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ Trello.logger = Logger.new(StringIO.new)
 
 RSpec.configure do |rspec|
   rspec.filter_run_excluding broken: true
+  rspec.filter_run_when_matching focus: true
 
   rspec.before :each do
     Trello.reset!


### PR DESCRIPTION
### Summary

The `#update_fields` issue which mentioned in https://github.com/jeremytregunna/ruby-trello/issues/272 happens in four models - Card, CustomFieldItem, CustomField, Label. 
I have done a fix for these four models. The fix may not be very DRY. But I think it's easy enough for reading and clearly enough to show what I have done.

### Things I have done:

1. Extract the old `#update_fields` method to a new `#initialize_fields` method in each problem model.
2. Refactor `#update_fields` to do two things
    1. Mark those **changed** **updateable** fields by call `"#{fieldName}_will_change!"`
    2. Call `#initialize_fields`
3. Override `#initialze` to call `#initialize_fields` instead of `#update_fields`

### Why I choose to fix it like this?

When I do some research on it, I find the `Card#update_fields` contains too much responsibility. And all these API models also have many different little details. It's hard to do a quick refactoring for all models. So I try to do a simple fix to keep it open to further refactoring. The current state may be a temporary state. But this issue has already been fixed. Further refactoring should belong to another PR.