### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Use schema to handle attribute register work
 * Standardize all data models' initialize/save/update!/update_fields process.
 * [Breaking] some data model's attribute names changes, check each data model for details
+* Support Ruby 3 (ActiveModel >= 6)
 
 ## v2.3.0
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ to, please just [create an issue](https://github.com/jeremytregunna/ruby-trello/
 ## Requirements
 
 Use the newest version for Ruby 2.5.0 or newer support. (Ruby 3 only works with ActiveModel 6 for now.)
+
 Use version 2.2.1 or earlier for Ruby 2.1 ~ 2.4 support.
+
 Use version 1.3.0 or earlier for Ruby 1.9.3 support.
+
 Use version 1.4.x or earlier for Ruby 2.0.0 support.
 
 ## Installation

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{ruby-trello}
-  s.version           = "2.3.1"
+  s.version           = "3.0.0"
   s.platform          = Gem::Platform::RUBY
   s.license           = 'MIT'
 


### PR DESCRIPTION
#### What does this PR do?

Release ruby-trello 3.0.0

###### Things in ruby-trello 3.0.0

* [Fix "Trello::Board#update! fail to update description"](https://github.com/jeremytregunna/ruby-trello/pull/289)
* [Add `Trello::List#move_to_board`](https://github.com/jeremytregunna/ruby-trello/pull/297)
* Use schema to handle attribute register work
* Standardize all data models' initialize/save/update!/update_fields process.
* [Breaking] some data model's attribute names changes, check each data model for details
* Support Ruby 3 (ActiveModel >= 6)