### PR TITLE
Fix truncation issue in CI configuration entries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,32 +19,32 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
           - 3.1
           - jruby
         active_model:
           - 4.2
           - 5.2
-          - 6.0
+          - '6.0'
           - 6.1
-          - 7.0
+          - '7.0'
         exclude:
           - ruby: 2.5
-            active_model: 7.0
+            active_model: '7.0'
           - ruby: 2.6
-            active_model: 7.0
+            active_model: '7.0'
           - ruby: 2.7
             active_model: 4.2
-          - ruby: 3.0
+          - ruby: '3.0'
             active_model: 4.2
-          - ruby: 3.0
+          - ruby: '3.0'
             active_model: 5.2
           - ruby: 3.1
             active_model: 4.2
           - ruby: 3.1
             active_model: 5.2
           - ruby: jruby
-            active_model: 7.0
+            active_model: '7.0'
 
     env:
       ACTIVE_MODEL_VERSION: "~> ${{ matrix.active_model }}.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,33 +16,33 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5
-          - 2.6
-          - 2.7
+          - '2.5'
+          - '2.6'
+          - '2.7'
           - '3.0'
-          - 3.1
+          - '3.1'
           - jruby
         active_model:
-          - 4.2
-          - 5.2
+          - '4.2'
+          - '5.2'
           - '6.0'
-          - 6.1
+          - '6.1'
           - '7.0'
         exclude:
-          - ruby: 2.5
+          - ruby: '2.5'
             active_model: '7.0'
-          - ruby: 2.6
+          - ruby: '2.6'
             active_model: '7.0'
-          - ruby: 2.7
-            active_model: 4.2
+          - ruby: '2.7'
+            active_model: '4.2'
           - ruby: '3.0'
-            active_model: 4.2
+            active_model: '4.2'
           - ruby: '3.0'
-            active_model: 5.2
-          - ruby: 3.1
-            active_model: 4.2
-          - ruby: 3.1
-            active_model: 5.2
+            active_model: '5.2'
+          - ruby: '3.1'
+            active_model: '4.2'
+          - ruby: '3.1'
+            active_model: '5.2'
           - ruby: jruby
             active_model: '7.0'
 


### PR DESCRIPTION
#### What does this PR do?

Zero terminated float values in GitHub Actions CI configurations are truncated, leading to unexpected behavior.  In this instance this results loading an unexpected Ruby or ActiveModel version for several CI matrix entries.

Specifically, the unquoted '3.0' is interpreted as '3', and the latest Ruby 3 version - at this time of writing 3.1.1 - is loaded.  To ensure that a 3.0.x version is loaded, we need to add quotes.

In the ActiveModel case, use of an unquoted '6.0' is interpreted as '6' and ActiveModel 6.1.4.6 is loaded at this time.  To ensure a 6.0.x version is loaded, we need to add quotes.

The unquoted '7.0' would have similar problems if and when a Rails 7.1.x is released..

#### Where should a reviewer start?

Look at the Actions tab for the CI runs and examine the setup Ruby step in detail for recent runs.  Once this runs, compare.

#### Screenshots
Note that the '3.0' is truncated and Ruby 3.1.1 is being loaded:

<img width="1338" alt="Screen Shot 2022-03-10 at 9 36 36 AM" src="https://user-images.githubusercontent.com/421488/157723573-a850f7fc-92ba-4d28-a438-45486480a53e.png">

