### PR TITLE
Remove rest-client dependency in the gemspec and default to faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :development, :spec do
     gem 'faraday', '~> 2.0'
   end
 
+  gem 'rest-client', '>= 1.8.0'
+
   if RUBY_ENGINE == 'jruby'
     gem 'jruby-openssl', platforms: :jruby
     gem 'pry-nav', platforms: :jruby

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ All the calls this library makes to Trello require authentication using these ke
 
 #### HTTP Client
 
-By default, ruby-trello uses [rest-client](https://rubygems.org/gems/rest-client) for network calls. You can configure ruby-trello to use either rest-client or [faraday](https://rubygems.org/gems/faraday), depending on your project's needs. In the next major version, ruby-trello will not require either gem in the gemspec and will default to faraday if both are present.
+ruby-trello requires either [rest-client](https://rubygems.org/gems/rest-client) or [faraday](https://rubygems.org/gems/faraday) to be present for network calls. You can configure ruby-trello to use either one, depending on your project's needs. If both are present, ruby-trello defaults to using faraday.
 
 ```ruby
 Trello.configure do |config|
-  config.http_client = 'rest-client'
-  # OR
   config.http_client = 'faraday'
+  # OR
+  config.http_client = 'rest-client'
 end
 ```
 

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -122,7 +122,7 @@ module Trello
   end
 
   # The order in which we will try the http clients
-  HTTP_CLIENT_PRIORITY = %w(rest-client faraday)
+  HTTP_CLIENT_PRIORITY = %w(faraday rest-client)
   HTTP_CLIENTS = {
     'faraday' => Trello::TFaraday::TInternet,
     'rest-client' => Trello::TRestClient::TInternet
@@ -141,7 +141,7 @@ module Trello
         end
       end
 
-      raise ConfigurationError, 'Trello requires either rest-client or faraday installed' unless client
+      raise ConfigurationError, 'Trello requires either faraday or rest-client installed' unless client
 
       client
     end

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json', '>= 2.3.0'
   s.add_dependency 'oauth',       '>= 0.4.5'
-  s.add_dependency 'rest-client', '>= 1.8.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,7 +74,7 @@ module IntegrationHelpers
     Trello.configure do |config|
       config.developer_public_key = ENV['TRELLO_DEVELOPER_PUBLIC_KEY'] || 'developerpublickey'
       config.member_token = ENV['TRELLO_MEMBER_TOKEN'] || 'membertoken'
-      config.http_client = ENV['HTTP_CLIENT_GEM'] || 'rest-client'
+      config.http_client = ENV['HTTP_CLIENT_GEM'] || 'faraday'
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?

This is a followup to https://github.com/jeremytregunna/ruby-trello/pull/307. This removes the gemspec dependency on rest-client to allow apps the option to remove their dependency on rest-client in favor of faraday (or other http clients in the future).

##### Why are we doing this? Any context or related work?

rest-client is out of date and does not appear to be actively maintained. This allows apps to remove the outdated gem from their dependency trees.

#### Where should a reviewer start?

The changes here are all configuration, so perhaps the best place to start is by running the tests.

#### Manual testing steps?

Include ruby-trello in a rails app and test it configured to use each of rest-client and faraday.
