### PR TITLE
Drop support for Ruby < 2.7 and Rails < 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,38 +16,16 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
-          - jruby
         active_model:
-          - '4.2'
-          - '5.2'
           - '6.0'
           - '6.1'
           - '7.0'
         http_client_gem:
           - 'rest-client'
           - 'faraday'
-        exclude:
-          - ruby: '2.5'
-            active_model: '7.0'
-          - ruby: '2.6'
-            active_model: '7.0'
-          - ruby: '2.7'
-            active_model: '4.2'
-          - ruby: '3.0'
-            active_model: '4.2'
-          - ruby: '3.0'
-            active_model: '5.2'
-          - ruby: '3.1'
-            active_model: '4.2'
-          - ruby: '3.1'
-            active_model: '5.2'
-          - ruby: jruby
-            active_model: '7.0'
 
     env:
       ACTIVE_MODEL_VERSION: "~> ${{ matrix.active_model }}.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - [Remove rest-client dependency in the gemspec and default to faraday](https://github.com/jeremytregunna/ruby-trello/pull/308)
+- [Drop support for Ruby < 2.7 and Rails < 6](https://github.com/jeremytregunna/ruby-trello/pull/310)
 
 ## v3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next release
+
+- [Remove rest-client dependency in the gemspec and default to faraday](https://github.com/jeremytregunna/ruby-trello/pull/308)
+
 ## v3.2.0
 
 - [Allow use of either rest-client of faraday](https://github.com/jeremytregunna/ruby-trello/pull/307)

--- a/Gemfile
+++ b/Gemfile
@@ -15,19 +15,8 @@ group :development, :spec do
   gem 'vcr'
   gem 'dotenv'
 
-  if RUBY_VERSION  < '2.6.0'
-    gem 'faraday', '~> 1.0'
-  else
-    gem 'faraday', '~> 2.0'
-  end
-
   gem 'rest-client', '>= 1.8.0'
 
-  if RUBY_ENGINE == 'jruby'
-    gem 'jruby-openssl', platforms: :jruby
-    gem 'pry-nav', platforms: :jruby
-  else
-    gem 'pry-byebug', '~> 3.9.0', :platforms => [:mri]
-  end
-  gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :jruby, :mingw]
+  gem 'pry-byebug', '~> 3.9.0', :platforms => [:mri]
+  gem 'simplecov', :require => false, :platforms => [:mri, :mri_18, :mri_19, :mingw]
 end

--- a/README.md
+++ b/README.md
@@ -15,22 +15,17 @@ to, please just [create an issue](https://github.com/jeremytregunna/ruby-trello/
 
 ## Requirements
 
-| Ruby  \  ActiveModel | 4.2 | 5.2 | 6.0 | 6.1 | 7.0 |
-| ---- | ---- | ---- | ---- | ---- | ---- |
-| 2.5 | ✅ | ✅ | ✅ | ✅ | ❌ |
-| 2.6 | ✅ | ✅ | ✅ | ✅ | ❌ |
-| 2.7 | ❌ | ✅ | ✅ | ✅ | ✅ |
-| 3.0 | ❌ | ❌ | ✅ | ✅ | ✅ |
-| 3.1 | ❌ | ❌ | ✅ | ✅ | ✅ |
-| jRuby 9.3 | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Ruby  \  ActiveModel | 6.0 | 6.1 | 7.0 |
+| ---- | ---- | ---- | ---- |
+| 2.7 | ✅ | ✅ | ✅ |
+| 3.0 | ✅ | ✅ | ✅ |
+| 3.1 | ✅ | ✅ | ✅ |
 
-Use the newest version for Ruby 2.5.0 or newer support.
-
-Use version 2.2.1 or earlier for Ruby 2.1 ~ 2.4 support.
-
-Use version 1.3.0 or earlier for Ruby 1.9.3 support.
-
-Use version 1.4.x or earlier for Ruby 2.0.0 support.
+- Use the newest version for Ruby 2.7.0 or newer support.
+- Use version 3.2.0 or earlier for Ruby 2.5 ~ 2.6 support.
+- Use version 2.2.1 or earlier for Ruby 2.1 ~ 2.4 support.
+- Use version 1.3.0 or earlier for Ruby 1.9.3 support.
+- Use version 1.4.x or earlier for Ruby 2.0.0 support.
 
 ## Installation
 

--- a/matrixeval.yml
+++ b/matrixeval.yml
@@ -11,12 +11,6 @@ parallel_workers: number_of_processors
 matrix:
   ruby:
     variants:
-      - key: 2.5
-        container:
-          image: ruby:2.5.9
-      - key: 2.6
-        container:
-          image: ruby:2.6.9
       - key: 2.7
         container:
           image: ruby:2.7.5
@@ -27,21 +21,13 @@ matrix:
       - key: 3.1
         container:
           image: ruby:3.1.0
-          env:
-            PATH: "/opt/jruby/bin:/app/bin:/bundle/bin:$PATH"
-      - key: jruby-9.3
-        container:
-          image: jruby:9.3
-          env:
-            PATH: "/opt/jruby/bin:/app/bin:/bundle/bin:$PATH"
+      # - key: jruby-9.3
+      #   container:
+      #     image: jruby:9.3
+      #     env:
+      #       PATH: "/opt/jruby/bin:/app/bin:/bundle/bin:$PATH"
   active_model:
     variants:
-      - key: 4.2
-        env:
-          ACTIVE_MODEL_VERSION: "~> 4.2.0"
-      - key: 5.2
-        env:
-          ACTIVE_MODEL_VERSION: "~> 5.2.0"
       - key: 6.0
         env:
           ACTIVE_MODEL_VERSION: "~> 6.0.0"
@@ -62,19 +48,5 @@ matrix:
         env:
           HTTP_CLIENT_GEM: "rest-client"
 exclude:
-  - ruby: 2.5
-    active_model: 7.0
-  - ruby: 2.6
-    active_model: 7.0
-  - ruby: 2.7
-    active_model: 4.2
-  - ruby: 3.0
-    active_model: 4.2
-  - ruby: 3.0
-    active_model: 5.2
-  - ruby: 3.1
-    active_model: 4.2
-  - ruby: 3.1
-    active_model: 5.2
-  - ruby: jruby-9.3
-    active_model: 7.0
+  # - ruby: jruby-9.3
+  #   active_model: 7.0

--- a/ruby-trello.gemspec
+++ b/ruby-trello.gemspec
@@ -18,10 +18,11 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob("spec/**/*")
   s.metadata['changelog_uri'] = 'https://github.com/jeremytregunna/ruby-trello/blob/master/CHANGELOG.md'
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.7.0'
 
-  s.add_dependency 'activemodel', '>= 3.2.0'
+  s.add_dependency 'activemodel', '>= 6.0.0'
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'json', '>= 2.3.0'
-  s.add_dependency 'oauth',       '>= 0.4.5'
+  s.add_dependency 'oauth', '>= 0.4.5'
+  s.add_dependency 'faraday', '~> 2.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,7 @@ require 'trello'
 require 'webmock/rspec'
 require 'stringio'
 require 'vcr'
-
-require 'pry-byebug' if RUBY_ENGINE != 'jruby'
+require 'pry-byebug'
 
 VCR.configure do |config|
   config.default_cassette_options = { match_requests_on: %i[uri method body] }


### PR DESCRIPTION
#### What does this PR do?

Because [oauth-ruby drop support for Ruby < 2.7 and Rails < 6](https://github.com/oauth-xx/oauth-ruby/blob/migrated/CHANGELOG.md). So we have to:
- Drop support for Ruby 2.5, 2.6
- Drop support for jRuby (May consider add it back, after jRuby upgrade to 2.7)
- Drop support for Rails 4 and 5
