### PR TITLE
Avoid warning: assigned but unused variable - comments

### DIFF
--- a/lib/trello/card.rb
+++ b/lib/trello/card.rb
@@ -303,7 +303,7 @@ module Trello
     # Retrieve a list of comments
     def comments(params = {})
       params[:filter] ||= "commentCard"
-      comments = Comment.from_response client.get("/cards/#{id}/actions", params)
+      Comment.from_response client.get("/cards/#{id}/actions", params)
     end
 
     # Find the creation date


### PR DESCRIPTION
#### What does this PR do?

It avoids a Ruby warning.

##### Why are we doing this? Any context or related work?

For clearer output.

#### Where should a reviewer start?

I had a warning like this when using this gem:

> /gems/gems/ruby-trello-4.2.0/lib/trello/card.rb:306: warning: assigned but unused variable - comments

#### Manual testing steps?

None.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a Ruby warning by removing an unused variable assignment in the comments method of the Trello card class.

- **Bug Fixes**:
    - Removed an unused variable assignment to avoid a Ruby warning in the comments method.

<!-- Generated by sourcery-ai[bot]: end summary -->